### PR TITLE
Support to customize spec MIME type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # APIFlask Change Log
 
+## Version 0.4.0
+Released: -
+
+- Add new configuration variables `YAML_SPEC_MIMETYPE` and `JSON_SPEC_MIMETYPE` to support
+    to customize the MIME type of spec response [pull #3](https://github.com/greyli/apiflask/pull/3).
+- Remove configuration variable `SPEC_TYPE`.
+
 ## Version 0.3.0
 Released: 2021/3/31
 

--- a/apiflask/__init__.py
+++ b/apiflask/__init__.py
@@ -13,4 +13,4 @@ from .security import HTTPTokenAuth
 from . import fields
 from . import validators
 
-__version__ = '0.3.1dev'
+__version__ = '0.4.0dev'

--- a/apiflask/settings.py
+++ b/apiflask/settings.py
@@ -13,7 +13,8 @@ LICENSE: Optional[Dict[str, str]] = None
 SERVERS: Optional[List[Dict[str, str]]] = None
 EXTERNAL_DOCS: Optional[Dict[str, str]] = None
 TERMS_OF_SERVICE: Optional[str] = None
-SPEC_FORMAT: str = 'json'
+YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'
+JSON_SPEC_MIMETYPE: str = 'application/json'
 # Automation behaviour control
 AUTO_TAGS: bool = True
 AUTO_DESCRIPTION: bool = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ def test_app_init(app):
     assert app
     assert hasattr(app, 'import_name')
     assert hasattr(app, 'title')
-    assert 'SPEC_FORMAT' in app.config
+    assert 'TAGS' in app.config
     assert 'openapi' in app.blueprints
 
 


### PR DESCRIPTION
Add new configs:

- `JSON_SPEC_MIMETYPE`
- `YAML_SPEC_MIMETYPE`

Remove config:

-  `SPEC_FORMAT`

Use `flask.jsonify` to generate a response object for dict response to prevent multiple content-type headers.

ref: https://github.com/pallets/flask/issues/3628