### PR TITLE
Optimize the import format

### DIFF
--- a/apiflask/__init__.py
+++ b/apiflask/__init__.py
@@ -1,16 +1,10 @@
 # flake8: noqa
 from .app import APIFlask
 from .blueprint import APIBlueprint
-from .decorators import input
-from .decorators import output
-from .decorators import doc
-from .decorators import auth_required
-from .exceptions import abort_json
-from .exceptions import HTTPError
+from .decorators import input, output, doc, auth_required
+from .exceptions import abort_json, HTTPError
 from .schemas import Schema
-from .security import HTTPBasicAuth
-from .security import HTTPTokenAuth
-from . import fields
-from . import validators
+from .security import HTTPBasicAuth, HTTPTokenAuth
+from . import fields, validators
 
 __version__ = '0.3.1dev'

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -1,7 +1,7 @@
 from typing import (
     Iterable, Union, List, Optional,
     Type, Tuple, Any, Dict
-) 
+)
 import re
 import sys
 

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -1,10 +1,11 @@
-from typing import Iterable, Union, List, Optional, Type, Tuple, Any, Dict
+from typing import (
+    Iterable, Union, List, Optional,
+    Type, Tuple, Any, Dict
+) 
 import re
 import sys
 
-from flask import Flask
-from flask import Blueprint
-from flask import render_template
+from flask import Flask, Blueprint, render_template
 from flask.config import ConfigAttribute
 from flask.globals import _request_ctx_stack
 from werkzeug.exceptions import HTTPException as WerkzeugHTTPException
@@ -16,16 +17,13 @@ try:
 except ImportError:
     sqla = None
 
-from .exceptions import HTTPError
-from .exceptions import default_error_handler
-from .utils import route_shortcuts
-from .utils import get_reason_phrase
-from .security import HTTPBasicAuth
-from .security import HTTPTokenAuth
+from .exceptions import HTTPError, default_error_handler
+from .utils import route_shortcuts, get_reason_phrase
+from .security import HTTPBasicAuth, HTTPTokenAuth
 from .schemas import Schema
-from .types import ResponseType
-from .types import ErrorCallbackType
-from .types import SpecCallbackType
+from .types import (
+    ResponseType, ErrorCallbackType, SpecCallbackType
+)
 
 
 @route_shortcuts

--- a/apiflask/blueprint.py
+++ b/apiflask/blueprint.py
@@ -1,8 +1,7 @@
 from typing import Optional, Union
 from flask import Blueprint
 
-from .utils import route_shortcuts
-from .utils import _sentinel
+from .utils import route_shortcuts, _sentinel
 
 
 @route_shortcuts

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -1,7 +1,7 @@
 from typing import (
     Callable, Union, List, Optional,
     Dict, Any, Type, Mapping
-) 
+)
 from functools import wraps
 from collections.abc import Mapping as ABCMapping
 

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -1,22 +1,21 @@
-from typing import Callable, Union, List, Optional, Dict, Any, Type, Mapping
+from typing import (
+    Callable, Union, List, Optional,
+    Dict, Any, Type, Mapping
+) 
 from functools import wraps
 from collections.abc import Mapping as ABCMapping
 
-from flask import Response
-from flask import jsonify
-from flask import current_app
+from flask import Response, jsonify, current_app
 from webargs.flaskparser import FlaskParser as BaseFlaskParser
 from marshmallow import ValidationError as MarshmallowValidationError
 
 from .exceptions import ValidationError
 from .utils import _sentinel
-from .schemas import Schema
-from .schemas import EmptySchema
-from .security import HTTPBasicAuth
-from .security import HTTPTokenAuth
-from .types import DecoratedType
-from .types import ResponseType
-from .types import RequestType
+from .schemas import Schema, EmptySchema
+from .security import HTTPBasicAuth, HTTPTokenAuth
+from .types import (
+    DecoratedType, ResponseType, RequestType
+)
 
 
 class FlaskParser(BaseFlaskParser):

--- a/apiflask/exceptions.py
+++ b/apiflask/exceptions.py
@@ -1,4 +1,7 @@
-from typing import Any, Optional, Mapping, Union, Tuple
+from typing import (
+    Any, Optional, Mapping,
+    Union, Tuple
+)
 
 from werkzeug.exceptions import default_exceptions
 

--- a/apiflask/fields.py
+++ b/apiflask/fields.py
@@ -1,33 +1,13 @@
 # flake8: noqa
-from marshmallow.fields import Field
-from marshmallow.fields import Raw
-from marshmallow.fields import Nested
-from marshmallow.fields import Mapping
-from marshmallow.fields import Dict
-from marshmallow.fields import List
-from marshmallow.fields import Tuple
-from marshmallow.fields import String
-from marshmallow.fields import UUID
-from marshmallow.fields import Number
-from marshmallow.fields import Integer
-from marshmallow.fields import Decimal
-from marshmallow.fields import Boolean
-from marshmallow.fields import Float
-from marshmallow.fields import DateTime
-from marshmallow.fields import NaiveDateTime
-from marshmallow.fields import AwareDateTime
-from marshmallow.fields import Time
-from marshmallow.fields import Date
-from marshmallow.fields import TimeDelta
-from marshmallow.fields import URL
-from marshmallow.fields import Email
-from marshmallow.fields import IP
-from marshmallow.fields import IPv4
-from marshmallow.fields import IPv6
-from marshmallow.fields import Method
-from marshmallow.fields import Function
-from marshmallow.fields import Constant
-from marshmallow.fields import Pluck
-from flask_marshmallow.fields import URLFor
-from flask_marshmallow.fields import Hyperlinks
-from flask_marshmallow.fields import AbsoluteURLFor
+from marshmallow.fields import (
+    Field, Raw, Nested, Mapping, Dict,
+    List, Tuple, String, UUID, Number,
+    Integer, Decimal, Boolean, Float,
+    DateTime, NaiveDateTime, AwareDateTime,
+    Time, Date, TimeDelta, URL, Email,
+    IP, IPv4, IPv6, Method, Function,
+    Constant, Pluck
+)
+from flask_marshmallow.fields import (
+    URLFor, Hyperlinks, AbsoluteURLFor
+)

--- a/apiflask/security.py
+++ b/apiflask/security.py
@@ -1,9 +1,11 @@
-from typing import Optional, Union, Tuple, Any, Mapping
-
+from typing import (
+    Optional, Union, Tuple, Any, Mapping
+)
 from flask import g, current_app
-from flask_httpauth import HTTPBasicAuth as BaseHTTPBasicAuth
-from flask_httpauth import HTTPTokenAuth as BaseHTTPTokenAuth
-
+from flask_httpauth import (
+    HTTPBasicAuth as BaseHTTPBasicAuth,
+    HTTPTokenAuth as BaseHTTPTokenAuth
+)
 from .exceptions import default_error_handler
 
 

--- a/apiflask/settings.py
+++ b/apiflask/settings.py
@@ -1,8 +1,10 @@
-from typing import Union, List, Optional, Dict
-
-from .schemas import Schema
-from .schemas import http_error_schema
-from .schemas import validation_error_schema
+from typing import (
+    Union, List, Optional, Dict
+)
+from .schemas import (
+    Schema, http_error_schema,
+    validation_error_schema
+)
 
 
 # OpenAPI fields

--- a/apiflask/types.py
+++ b/apiflask/types.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, TypeVar, Union, Dict, List, Tuple, Mapping
+from typing import (
+    Any, Callable, TypeVar, Union,
+    Dict, List, Tuple, Mapping
+)
 
 from flask.wrappers import Response
 

--- a/apiflask/validators.py
+++ b/apiflask/validators.py
@@ -1,13 +1,6 @@
 # flake8: noqa
-from marshmallow.validate import ContainsNoneOf
-from marshmallow.validate import ContainsOnly
-from marshmallow.validate import Email
-from marshmallow.validate import Equal
-from marshmallow.validate import Length
-from marshmallow.validate import NoneOf
-from marshmallow.validate import OneOf
-from marshmallow.validate import Predicate
-from marshmallow.validate import Range
-from marshmallow.validate import Regexp
-from marshmallow.validate import URL
-from marshmallow.validate import Validator
+from marshmallow.validate import (
+    ContainsNoneOf, ContainsOnly, Email, Equal,
+    Length, NoneOf, OneOf, Predicate, Range,
+    Regexp, URL, Validator
+)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,9 @@
 import pytest
 from openapi_spec_validator import validate_spec
 
-from apiflask import APIBlueprint, input, output, auth_required, doc
+from apiflask import (
+    APIBlueprint, input, output, auth_required, doc
+)
 from apiflask.security import HTTPBasicAuth, HTTPTokenAuth
 from apiflask.fields import String
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,8 @@
 import pytest
 
-from apiflask.exceptions import abort_json, HTTPError, default_error_handler
+from apiflask.exceptions import (
+    abort_json, HTTPError, default_error_handler
+)
 from apiflask.utils import get_reason_phrase
 
 

--- a/tests/test_openapi_paths.py
+++ b/tests/test_openapi_paths.py
@@ -1,7 +1,9 @@
 from openapi_spec_validator import validate_spec
 
 from apiflask import input, output
-from .schemas import FooSchema, QuerySchema, PaginationSchema, HeaderSchema
+from .schemas import (
+    FooSchema, QuerySchema, PaginationSchema, HeaderSchema
+)
 
 
 def test_spec_path_summary_description_from_docs(app, client):

--- a/tests/test_openapi_security.py
+++ b/tests/test_openapi_security.py
@@ -1,7 +1,9 @@
 import pytest
 from openapi_spec_validator import validate_spec
 
-from apiflask import HTTPBasicAuth, HTTPTokenAuth, auth_required
+from apiflask import (
+    HTTPBasicAuth, HTTPTokenAuth, auth_required
+)
 
 
 def test_httpbasicauth_security_scheme(app, client):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,7 +7,10 @@ from apiflask.schemas import EmptySchema, http_error_schema
 from apiflask.security import HTTPBasicAuth
 
 from .schemas import QuerySchema, FooSchema
-from .schemas import ValidationErrorSchema, AuthorizationErrorSchema, HTTPErrorSchema
+from .schemas import (
+    ValidationErrorSchema, AuthorizationErrorSchema,
+    HTTPErrorSchema
+)
 
 
 def test_openapi_fields(app, client):


### PR DESCRIPTION
Optimize the import format using Python's standard grouping mechanism (parentheses), refering to [PEP 328](https://legacy.python.org/dev/peps/pep-0328/#rationale-for-absolute-imports).