### PR TITLE
Improve 204 response handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,12 @@
 Released: -
 
 - Add new configuration variables `YAML_SPEC_MIMETYPE` and `JSON_SPEC_MIMETYPE` to support
-    to customize the MIME type of spec response [pull #3](https://github.com/greyli/apiflask/pull/3).
+    to customize the MIME type of spec response ([pull #3][pull_3]).
 - Remove configuration variable `SPEC_TYPE`.
+- Fix the support to pass an empty dict as schema for 204 response ([pull #3][pull_13]).
+
+[pull_3]: https://github.com/greyli/apiflask/pull/3
+[pull_13]: https://github.com/greyli/apiflask/pull/13
 
 ## Version 0.3.0
 Released: 2021/3/31

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -462,7 +462,7 @@ class APIFlask(Flask):
     def _generate_spec(self) -> APISpec:
         """Generate the spec, return an instance of `apispec.APISpec`.
         """
-        def resolver(schema: Schema) -> str:
+        def resolver(schema: Type[Schema]) -> str:
             name = schema.__class__.__name__
             if name.endswith('Schema'):
                 name = name[:-6] or name
@@ -526,8 +526,8 @@ class APIFlask(Flask):
         if self.external_docs:
             kwargs['externalDocs'] = self.external_docs
 
-        ma_plugin: Type[MarshmallowPlugin] = MarshmallowPlugin(schema_name_resolver=resolver)
-        spec: Type[APISpec] = APISpec(
+        ma_plugin: MarshmallowPlugin = MarshmallowPlugin(schema_name_resolver=resolver)
+        spec: APISpec = APISpec(
             title=self.title,
             version=self.version,
             openapi_version='3.0.3',
@@ -546,12 +546,12 @@ class APIFlask(Flask):
                 ('string', 'url')
 
         # security schemes
-        auth_schemes: List[Union[Type[HTTPBasicAuth], Type[HTTPTokenAuth]]] = []
+        auth_schemes: List[Union[HTTPBasicAuth, HTTPTokenAuth]] = []
         auth_names: List[str] = []
         auth_blueprints: Dict[str, Dict[str, Any]] = {}
 
         def add_auth_schemes_and_names(
-            auth: Union[Type[HTTPBasicAuth], Type[HTTPTokenAuth]]
+            auth: Union[HTTPBasicAuth, HTTPTokenAuth]
         ) -> None:
             auth_schemes.append(auth)
             if isinstance(auth, HTTPBasicAuth):
@@ -591,7 +591,7 @@ class APIFlask(Flask):
                 if auth is not None and auth not in auth_schemes:
                     add_auth_schemes_and_names(auth)
 
-        security: Dict[Union[Type[HTTPBasicAuth], Type[HTTPTokenAuth]], str] = {}
+        security: Dict[Union[HTTPBasicAuth, HTTPTokenAuth], str] = {}
         security_schemes: Dict[str, Dict[str, str]] = {}
         for name, auth in zip(auth_names, auth_schemes):
             security[auth] = name
@@ -722,7 +722,7 @@ class APIFlask(Flask):
 
                 def add_response(
                     status_code: str,
-                    schema: Union[Schema, dict],
+                    schema: Union[Type[Schema], dict],
                     description: str,
                     example: Optional[Any] = None
                 ) -> None:
@@ -740,12 +740,12 @@ class APIFlask(Flask):
 
                 def add_response_with_schema(
                     status_code: str,
-                    schema: Union[Schema, dict],
+                    schema: Union[Type[Schema], dict],
                     schema_name: str,
                     description: str
                 ) -> None:
                     if isinstance(schema, type):
-                        schema = schema()
+                        schema = schema()  # type: ignore
                         add_response(status_code, schema, description)
                     elif isinstance(schema, dict):
                         if schema_name not in spec.components.schemas:
@@ -781,7 +781,7 @@ class APIFlask(Flask):
                             'VALIDATION_ERROR_DESCRIPTION'
                         ]
                         schema: Union[  # type: ignore
-                            Schema, dict
+                            Type[Schema], dict
                         ] = self.config['VALIDATION_ERROR_SCHEMA']
                         add_response_with_schema(
                             status_code, schema, 'ValidationError', description
@@ -797,7 +797,7 @@ class APIFlask(Flask):
                         )
                         description: str = self.config['AUTH_ERROR_DESCRIPTION']  # type: ignore
                         schema: Union[  # type: ignore
-                            Schema, dict
+                            Type[Schema], dict
                         ] = self.config['AUTH_ERROR_SCHEMA']
                         add_response_with_schema(
                             status_code, schema, 'AuthorizationError', description
@@ -821,7 +821,7 @@ class APIFlask(Flask):
                             status_code.startswith('5')  # type: ignore
                         ):
                             schema: Union[  # type: ignore
-                                Schema, dict
+                                Type[Schema], dict
                             ] = self.config['HTTP_ERROR_SCHEMA']
                             add_response_with_schema(
                                 status_code, schema, 'HTTPError', description

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -726,13 +726,13 @@ class APIFlask(Flask):
                     description: str,
                     example: Optional[Any] = None
                 ) -> None:
-                    operation['responses'][status_code] = {
-                        'content': {
+                    operation['responses'][status_code] = {}
+                    if status_code != '204':
+                        operation['responses'][status_code]['content'] = {
                             'application/json': {
                                 'schema': schema
                             }
                         }
-                    }
                     operation['responses'][status_code]['description'] = description
                     if example is not None:
                         operation['responses'][status_code]['content'][

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -208,7 +208,9 @@ def output(
             a `dict` schema (e.g. `{'name': String()}`).
         example: The example data for response.
     """
-    if isinstance(schema, ABCMapping) and schema != {}:
+    if schema == {}:
+        schema = EmptySchema
+    if isinstance(schema, ABCMapping):
         schema = _generate_schema_from_mapping(schema, schema_name)
     if isinstance(schema, type):  # pragma: no cover
         schema = schema()

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -53,7 +53,7 @@ def _annotate(f: Any, **kwargs: Any) -> None:
 
 
 def auth_required(
-    auth: Union[Type[HTTPBasicAuth], Type[HTTPTokenAuth]],
+    auth: Union[HTTPBasicAuth, HTTPTokenAuth],
     role: Optional[Union[list, str]] = None,
     optional: Optional[str] = None
 ) -> Callable[[DecoratedType], DecoratedType]:
@@ -103,7 +103,7 @@ def _generate_schema_from_mapping(schema, schema_name):
 
 
 def input(
-    schema: Schema,
+    schema: Type[Schema],
     location: str = 'json',
     schema_name: Optional[str] = None,
     example: Optional[Any] = None,
@@ -145,7 +145,7 @@ def input(
     if isinstance(schema, ABCMapping):
         schema = _generate_schema_from_mapping(schema, schema_name)
     if isinstance(schema, type):  # pragma: no cover
-        schema = schema()
+        schema = schema()  # type: ignore
 
     def decorator(f):
         if location not in [
@@ -168,7 +168,7 @@ def input(
 
 
 def output(
-    schema: Schema,
+    schema: Type[Schema],
     status_code: int = 200,
     description: Optional[str] = None,
     schema_name: Optional[str] = None,
@@ -213,7 +213,7 @@ def output(
     if isinstance(schema, ABCMapping):
         schema = _generate_schema_from_mapping(schema, schema_name)
     if isinstance(schema, type):  # pragma: no cover
-        schema = schema()
+        schema = schema()  # type: ignore
 
     if isinstance(schema, EmptySchema):
         status_code = 204

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -80,11 +80,11 @@ def auth_required(
         auth: The `auth` object, an instance of [`HTTPBasicAuth`][apiflask.security.HTTPBasicAuth]
             or [`HTTPTokenAuth`][apiflask.security.HTTPTokenAuth].
         role: The selected role to allow to visit this view, accepts a string or a list.
-            See [Flask-HTTPAuth's documentation](role) for more details.
+            See [Flask-HTTPAuth's documentation][role] for more details.
+            [role]: https://flask-httpauth.readthedocs.io/en/latest/#user-roles
         optional: To allow the view to execute even the authentication information
             is not included with the request, in which case `auth.current_user` will be `None`.
 
-    [role]: https://flask-httpauth.readthedocs.io/en/latest/#user-roles
     """
     roles = role
     if not isinstance(role, list):  # pragma: no cover

--- a/apiflask/settings.py
+++ b/apiflask/settings.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Optional, Dict
+from typing import Union, List, Optional, Dict, Type
 
 from .schemas import Schema
 from .schemas import http_error_schema
@@ -29,13 +29,13 @@ DEFAULT_204_DESCRIPTION: str = 'Empty response'
 AUTO_VALIDATION_ERROR_RESPONSE: bool = True
 VALIDATION_ERROR_STATUS_CODE: int = 400
 VALIDATION_ERROR_DESCRIPTION: str = 'Validation error'
-VALIDATION_ERROR_SCHEMA: Union[Schema, dict] = validation_error_schema
+VALIDATION_ERROR_SCHEMA: Union[Type[Schema], dict] = validation_error_schema
 AUTO_AUTH_ERROR_RESPONSE: bool = True
 AUTH_ERROR_STATUS_CODE: int = 401
 AUTH_ERROR_DESCRIPTION: str = 'Authentication error'
-AUTH_ERROR_SCHEMA: Union[Schema, dict] = http_error_schema
+AUTH_ERROR_SCHEMA: Union[Type[Schema], dict] = http_error_schema
 AUTO_HTTP_ERROR_RESPONSE: bool = True
-HTTP_ERROR_SCHEMA: Union[Schema, dict] = http_error_schema
+HTTP_ERROR_SCHEMA: Union[Type[Schema], dict] = http_error_schema
 # Swagger UI and Redoc
 DOCS_HIDE_BLUEPRINTS: List[str] = []
 DOCS_FAVICON: Optional[str] = None

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,6 +1,7 @@
 from apiflask import APIFlask, Schema, input, output, abort_json
 from apiflask.fields import Integer, String
 from apiflask.validators import Length, OneOf
+from apiflask.schemas import EmptySchema
 
 app = APIFlask(__name__)
 
@@ -85,7 +86,7 @@ def partial_update_pet(pet_id, data):
 
 
 @app.delete('/pets/<int:pet_id>')
-@output({}, 204)
+@output(EmptySchema, 204)
 def delete_pet(pet_id):
     if pet_id > len(pets) - 1:
         abort_json(404)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -405,6 +405,21 @@ def test_output_body_example(app, client):
         'content']['application/json']['example'] == {'name': 'foo', 'age': 20}
 
 
+def test_output_with_empty_dict_as_schema(app, client):
+    @app.delete('/foo')
+    @output({}, 204)
+    def delete_foo():
+        return ''
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert 'content' not in rv.json['paths']['/foo']['delete']['responses']['204']
+
+    rv = client.delete('/foo')
+    assert rv.status_code == 204
+
+
 def test_doc_summary_and_description(app, client):
     @app.route('/foo')
     @doc(summary='summary from doc decorator')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -397,16 +397,14 @@ def test_http_auth_error_response(app, client, config_value):
         assert '#/components/schemas/HTTPError' in \
             rv.json['paths']['/foo']['get']['responses']['500'][
                 'content']['application/json']['schema']['$ref']
-        assert rv.json['paths']['/foo']['get']['responses']['204'][
-                'content']['application/json']['schema'] == {}
+        assert 'content' not in rv.json['paths']['/foo']['get']['responses']['204']
     else:
         assert 'HTTPError' not in rv.json['components']['schemas']
         assert rv.json['paths']['/foo']['get']['responses']['404'][
                 'content']['application/json']['schema'] == {}
         assert rv.json['paths']['/foo']['get']['responses']['500'][
                 'content']['application/json']['schema'] == {}
-        assert rv.json['paths']['/foo']['get']['responses']['204'][
-                'content']['application/json']['schema'] == {}
+        assert 'content' not in rv.json['paths']['/foo']['get']['responses']['204']
 
 
 @pytest.mark.parametrize('schema', [


### PR DESCRIPTION
- Fix the support to pass an empty dict as schema for 204 response.
- Do not add `content` into spec for 204 response.
- Fix type annotation for schema and auth object.

Fix #11 