### PR TITLE
Support set multiple examples for request/response body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,10 +27,13 @@ Released: -
     to customize the MIME type of spec response ([pull #3][pull_3]).
 - Remove configuration variable `SPEC_TYPE`.
 - Fix the support to pass an empty dict as schema for 204 response ([pull #12][pull_12]).
+- Support set multiple examples for request/response body with `@output(examples=...)`
+and `@iniput(examples=...)` ([pull #23][pull_23]).
 
 [pull_3]: https://github.com/greyli/apiflask/pull/3
 [pull_12]: https://github.com/greyli/apiflask/pull/12
 [pull_7]: https://github.com/greyli/apiflask/pull/7
+[pull_23]: https://github.com/greyli/apiflask/pull/23
 
 ## Version 0.3.0
 Released: 2021/3/31

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -647,7 +647,11 @@ class APIFlask(Flask):
                     continue
             # add a default 200 response for bare views
             default_response = {
-                'schema': {}, 'status_code': 200, 'description': None, 'example': None
+                'schema': {},
+                'status_code': 200,
+                'description': None,
+                'example': None,
+                'examples': None
             }
             if not hasattr(view_func, '_spec'):
                 if self.config['AUTO_200_RESPONSE']:
@@ -725,7 +729,8 @@ class APIFlask(Flask):
                     status_code: str,
                     schema: SchemaType,
                     description: str,
-                    example: Optional[Any] = None
+                    example: Optional[Any] = None,
+                    examples: Optional[Dict[str, Any]] = None,
                 ) -> None:
                     operation['responses'][status_code] = {}
                     if status_code != '204':
@@ -738,6 +743,9 @@ class APIFlask(Flask):
                     if example is not None:
                         operation['responses'][status_code]['content'][
                             'application/json']['example'] = example
+                    if examples is not None:
+                        operation['responses'][status_code]['content'][
+                            'application/json']['examples'] = examples
 
                 def add_response_with_schema(
                     status_code: str,
@@ -765,7 +773,8 @@ class APIFlask(Flask):
                     description: str = view_func._spec.get('response')['description'] or \
                         self.config['SUCCESS_DESCRIPTION']
                     example = view_func._spec.get('response')['example']
-                    add_response(status_code, schema, description, example)
+                    examples = view_func._spec.get('response')['examples']
+                    add_response(status_code, schema, description, example, examples)
                 else:
                     # add a default 200 response for views without using @output
                     # or @doc(responses={...})
@@ -832,8 +841,13 @@ class APIFlask(Flask):
                         }
                     }
                     if view_func._spec.get('body_example'):
+                        example = view_func._spec.get('body_example')
                         operation['requestBody']['content'][
-                            'application/json']['example'] = view_func._spec.get('body_example')
+                            'application/json']['example'] = example
+                    if view_func._spec.get('body_examples'):
+                        examples = view_func._spec.get('body_examples')
+                        operation['requestBody']['content'][
+                            'application/json']['examples'] = examples
 
                 # security
                 if blueprint_name is not None and blueprint_name in auth_blueprints:

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -117,6 +117,7 @@ def input(
     location: str = 'json',
     schema_name: Optional[str] = None,
     example: Optional[Any] = None,
+    examples: Optional[Dict[str, Any]] = None,
     **kwargs: Any
 ) -> Callable[[DecoratedType], DecoratedType]:
     """Add input settings for view functions.
@@ -150,7 +151,21 @@ def input(
         schema_name: The schema name for dict schema, only needed when you pass
             a `dict` schema (e.g. `{'name': String(required=True)}`) for `json`
             location.
-        example: The example data for request body.
+        example: The example data in dict for request body, you should use either
+            `example` or `examples`, not both.
+        examples: Multiple examples for request body, you should pass a dict
+            that contains multiple examples. Example:
+            ```python
+            {
+                'example foo': {  # example name
+                    'summary': 'an example of foo',  # summary field is optional
+                    'value': {'name': 'foo', 'id': 1}  # example value
+                },
+                'example bar': {
+                    'summary': 'an example of bar',
+                    'value': {'name': 'bar', 'id': 2}
+                },
+            }
     """
     if isinstance(schema, ABCMapping):
         schema = _generate_schema_from_mapping(schema, schema_name)
@@ -167,7 +182,7 @@ def input(
                 f' Got "{location}" instead.'
             )
         if location == 'json':
-            _annotate(f, body=schema, body_example=example)
+            _annotate(f, body=schema, body_example=example, body_examples=examples)
         else:
             if not hasattr(f, '_spec') or f._spec.get('args') is None:
                 _annotate(f, args=[])
@@ -182,7 +197,8 @@ def output(
     status_code: int = 200,
     description: Optional[str] = None,
     schema_name: Optional[str] = None,
-    example: Optional[Any] = None
+    example: Optional[Any] = None,
+    examples: Optional[Dict[str, Any]] = None
 ) -> Callable[[DecoratedType], DecoratedType]:
     """Add output settings for view functions.
 
@@ -216,7 +232,22 @@ def output(
         description: The description of the response.
         schema_name: The schema name for dict schema, only needed when you pass
             a `dict` schema (e.g. `{'name': String()}`).
-        example: The example data for response.
+        example: The example data in dict for response body, you should use either
+            `example` or `examples`, not both.
+        examples: Multiple examples for response body, you should pass a dict
+            that contains multiple examples. Example:
+            ```python
+            {
+                'example foo': {  # example name
+                    'summary': 'an example of foo',  # summary field is optional
+                    'value': {'name': 'foo', 'id': 1}  # example value
+                },
+                'example bar': {
+                    'summary': 'an example of bar',
+                    'value': {'name': 'bar', 'id': 2}
+                },
+            }
+            ```
     """
     if schema == {}:
         schema = EmptySchema
@@ -233,7 +264,8 @@ def output(
             'schema': schema,
             'status_code': status_code,
             'description': description,
-            'example': example
+            'example': example,
+            'examples': examples
         })
 
         def _jsonify(obj, many=_sentinel, *args, **kwargs):  # pragma: no cover

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -261,13 +261,25 @@ def test_input_with_dict_schema(app, client):
 
 
 def test_input_body_example(app, client):
+    example = {'name': 'foo', 'id': 2}
+    examples = {
+        'example foo': {
+            'summary': 'an example of foo',
+            'value': {'name': 'foo', 'id': 1}
+        },
+        'example bar': {
+            'summary': 'an example of bar',
+            'value': {'name': 'bar', 'id': 2}
+        },
+    }
+
     @app.post('/foo')
-    @input(FooSchema, example=['foo', 'bar', 'baz'])
+    @input(FooSchema, example=example)
     def foo():
         pass
 
     @app.post('/bar')
-    @input(FooSchema, example={'name': 'foo', 'age': 20})
+    @input(FooSchema, examples=examples)
     def bar():
         pass
 
@@ -275,9 +287,9 @@ def test_input_body_example(app, client):
     assert rv.status_code == 200
     validate_spec(rv.json)
     assert rv.json['paths']['/foo']['post']['requestBody'][
-        'content']['application/json']['example'] == ['foo', 'bar', 'baz']
+        'content']['application/json']['example'] == example
     assert rv.json['paths']['/bar']['post']['requestBody'][
-        'content']['application/json']['example'] == {'name': 'foo', 'age': 20}
+        'content']['application/json']['examples'] == examples
 
 
 def test_output(app, client):
@@ -393,13 +405,25 @@ def test_output_with_dict_schema(app, client):
 
 
 def test_output_body_example(app, client):
+    example = {'name': 'foo', 'id': 2}
+    examples = {
+        'example foo': {
+            'summary': 'an example of foo',
+            'value': {'name': 'foo', 'id': 1}
+        },
+        'example bar': {
+            'summary': 'an example of bar',
+            'value': {'name': 'bar', 'id': 2}
+        },
+    }
+
     @app.get('/foo')
-    @output(FooSchema, example=['foo', 'bar', 'baz'])
+    @output(FooSchema, example=example)
     def foo():
         pass
 
     @app.get('/bar')
-    @output(FooSchema, example={'name': 'foo', 'age': 20})
+    @output(FooSchema, examples=examples)
     def bar():
         pass
 
@@ -407,9 +431,9 @@ def test_output_body_example(app, client):
     assert rv.status_code == 200
     validate_spec(rv.json)
     assert rv.json['paths']['/foo']['get']['responses']['200'][
-        'content']['application/json']['example'] == ['foo', 'bar', 'baz']
+        'content']['application/json']['example'] == example
     assert rv.json['paths']['/bar']['get']['responses']['200'][
-        'content']['application/json']['example'] == {'name': 'foo', 'age': 20}
+        'content']['application/json']['examples'] == examples
 
 
 def test_output_with_empty_dict_as_schema(app, client):


### PR DESCRIPTION
Add a new `examples` for `@input` and `@output` decorators to pass multiple example values for request/response body:

```py

pet_examples = {
    'example foo': {
        'summary': 'an example of foo',
        'value': {'name': 'foo', 'id': 1}
    },
    'example bar': {
        'summary': 'an example of bar',
        'value': {'name': 'bar', 'id': 2}
    },
}

@app.get('/pets/<int:pet_id>')
@output(PetOutSchema, examples=pet_examples)
def get_pet(pet_id):
    if pet_id > len(pets) - 1:
        abort_json(404)
    return pets[pet_id]
```

Checklist:

- [x] Add tests
- [x] Update changelog