### PR TITLE
Add auth_required(roles) and doc(tags) arguments for list value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,11 +29,14 @@ Released: -
 - Fix the support to pass an empty dict as schema for 204 response ([pull #12][pull_12]).
 - Support set multiple examples for request/response body with `@output(examples=...)`
 and `@iniput(examples=...)` ([pull #23][pull_23]).
+- Add `auth_required(roles=...)` and `doc(tags=...)` arguments for list value, `role` and
+`tag` argument now only accept string value ([pull #26][pull_26]).
 
 [pull_3]: https://github.com/greyli/apiflask/pull/3
 [pull_12]: https://github.com/greyli/apiflask/pull/12
 [pull_7]: https://github.com/greyli/apiflask/pull/7
 [pull_23]: https://github.com/greyli/apiflask/pull/23
+[pull_26]: https://github.com/greyli/apiflask/pull/26
 
 ## Version 0.3.0
 Released: 2021/3/31

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -663,20 +663,20 @@ class APIFlask(Flask):
                 continue
 
             # tag
-            operation_tags: Optional[Union[str, List[str]]] = None
-            if view_func._spec.get('tag'):
-                operation_tags = view_func._spec.get('tag')
+            operation_tags: Optional[List[str]] = None
+            if view_func._spec.get('tags'):
+                operation_tags = view_func._spec.get('tags')
             else:
                 # if tag not set, try to use blueprint name as tag
                 if self.tags is None and self.config['AUTO_TAGS'] and blueprint_name is not None:
                     blueprint = self.blueprints[blueprint_name]
                     if hasattr(blueprint, 'tag') and blueprint.tag is not None:
                         if isinstance(blueprint.tag, dict):
-                            operation_tags = blueprint.tag['name']
+                            operation_tags = [blueprint.tag['name']]
                         else:
-                            operation_tags = blueprint.tag
+                            operation_tags = [blueprint.tag]
                     else:
-                        operation_tags = blueprint_name.title()
+                        operation_tags = [blueprint_name.title()]
 
             for method in ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']:
                 if method not in rule.methods:
@@ -689,10 +689,7 @@ class APIFlask(Flask):
                     'responses': {},
                 }
                 if operation_tags:
-                    if isinstance(operation_tags, list):
-                        operation['tags'] = operation_tags
-                    else:
-                        operation['tags'] = [operation_tags]
+                    operation['tags'] = operation_tags
 
                 # summary
                 if view_func._spec.get('summary'):

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -95,7 +95,7 @@ def auth_required(
             is not included with the request, in which case `auth.current_user` will be `None`.
     """
     _roles = None
-    if role is not None and not isinstance(role, list):
+    if role is not None:
         _roles = [role]
     elif roles is not None:
         _roles = roles
@@ -355,7 +355,7 @@ def doc(
     *Version added: 0.2.0*
     """
     _tags = None
-    if tag is not None and not isinstance(tag, list):
+    if tag is not None:
         _tags = [tag]
     elif tags is not None:
         _tags = tags


### PR DESCRIPTION
Actually, without this PR, the `role` and `tag` argument can also handle list value. This change basically used to make the API more consistent since we have `example` and `examples`. 

Example usage for roles:

```py
@app.get('/baz')
@auth_required(auth, roles=['admin', 'moderator'])
def baz():
    return auth.current_user
```

Example usage for tags:

```py
@app.get('/bar')
@doc(tags=['foo', 'bar'])
def bar():
    pass
```

Checklist:

- [x] Update changelog
- [x] Add tests