### PR TITLE
Skip raw blueprint from OpenAPI generating

### DIFF
--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -519,7 +519,9 @@ class APIFlask(Flask):
             if self.config['AUTO_TAGS']:
                 # auto-generate tags from blueprints
                 for blueprint_name, blueprint in self.blueprints.items():
-                    if blueprint_name == 'openapi' or not blueprint.enable_openapi:
+                    if blueprint_name == 'openapi' or \
+                       not hasattr(blueprint, 'enable_openapi') or \
+                       not blueprint.enable_openapi:
                         continue
                     tag: Dict[str, Any] = get_tag(blueprint, blueprint_name)
                     tags.append(tag)  # type: ignore
@@ -614,7 +616,8 @@ class APIFlask(Flask):
             blueprint_name: Optional[str] = None  # type: ignore
             if '.' in rule.endpoint:
                 blueprint_name = rule.endpoint.split('.', 1)[0]
-                if not self.blueprints[blueprint_name].enable_openapi:
+                if not hasattr(self.blueprints[blueprint_name], 'enable_openapi') or \
+                   not self.blueprints[blueprint_name].enable_openapi:
                     continue
             # add a default 200 response for bare views
             if not hasattr(view_func, '_spec'):

--- a/apiflask/route.py
+++ b/apiflask/route.py
@@ -17,7 +17,7 @@ def route_patch(cls):
             if isinstance(f, MethodViewType):
                 # MethodView class
                 view_func = f.as_view(endpoint)
-                if self.enable_openapi:
+                if hasattr(self, 'enable_openapi') and self.enable_openapi:
                     view_func._method_spec = {}
                     if not hasattr(view_func, '_spec'):
                         view_func._spec = {}


### PR DESCRIPTION
Some extension will create the blueprint, APIFlask needs to skip them when generating the OpenAPI spec file.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Run `pytest` and `tox`, no tests failed.
