### PR TITLE
Return Response object directly in output decorator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,10 +16,14 @@ $ pip show apiflask
 
 0.6.0 plan: <https://github.com/greyli/apiflask/issues/31>
 
+- Allow to return a `Response` object in a view function decorated with `output`. In
+this case, APIFlask will do nothing but return it directly.
+
 ## Version 0.5.1
 Released: 2021/4/28
 
 - Change the default endpoint of the view class to the original class name (not lowercase).
+- Allow to pass the `methods` arugment for the `route` decorator on view classes.
 
 ## Version 0.5.0
 Released: 2021/4/27

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -295,9 +295,8 @@ def output(
         @wraps(f)
         def _response(*args: Any, **kwargs: Any) -> ResponseType:
             rv = f(*args, **kwargs)
-            if isinstance(rv, Response):  # pragma: no cover
-                raise RuntimeError(
-                    'The @output decorator cannot handle Response objects.')
+            if isinstance(rv, Response):
+                return rv
             if not isinstance(rv, tuple):
                 return _jsonify(rv), status_code
             json = _jsonify(rv[0])

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -211,12 +211,10 @@ def bar():
 
 ### The return values of view function
 
-When you added a `@output` decorator for your view function, notice the
-following rules:
-
-- Do not return a `Response` object. You should return a ORM/ODM model object or
-a dict that matches the schema you passed in the `@output` decorator.
-- You can also return a two-element tuple in the form of `(body, headers)`.
+When you added a `@output` decorator for your view function, APIFlask expects you to
+return an ORM/ODM model object or a dict that matches the schema you passed in the
+`@output` decorator. If you return a `Response` object, APIFlask will return it
+directly without any process.
 
 ## Next step
 

--- a/tests/test_decorator_output.py
+++ b/tests/test_decorator_output.py
@@ -1,3 +1,4 @@
+from flask import make_response
 from flask.views import MethodView
 from openapi_spec_validator import validate_spec
 
@@ -226,3 +227,14 @@ def test_output_with_empty_dict_as_schema(app, client):
     assert rv.status_code == 204
     rv = client.delete('/bar')
     assert rv.status_code == 204
+
+
+def test_output_response_object_directly(app, client):
+    @app.get('/foo')
+    @output(FooSchema)
+    def foo():
+        return make_response({'message': 'hello'})
+
+    rv = client.get('/foo')
+    assert rv.status_code == 200
+    assert rv.json['message'] == 'hello'


### PR DESCRIPTION
Allow returning a `Response` object in a view function decorated with `output`. In this case, APIFlask will do nothing but return it directly.