### PR TITLE
Support using async views for Flask 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 0.6.0 plan: <https://github.com/greyli/apiflask/issues/31>
 
+- Support using the `output` decorator on async views.
+
 
 ## Version 0.5.2
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ def update_pet(pet_id, data):
 ```
 
 <details>
-<summary>Click to see the same example with <strong>class-based views</strong></summary>
+<summary>You can also use class-based views with <code>MethodView</code></summary>
 
 ```python
 from apiflask import APIFlask, Schema, input, output, abort
@@ -182,6 +182,32 @@ class Pet(MethodView):
             pets[pet_id][attr] = value
         return pets[pet_id]
 ```
+</details>
+
+<details>
+<summary>Or use <code>async def</code> with Flask 2.0</summary>
+
+Flask 2.0 has the basic support for <code>async</code> and <code>await</code>, check it out with Flask 2.0.0rc:
+
+```bash
+$ pip install --pre flask[async]
+```
+
+```python
+import asyncio
+
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+
+@app.get('/')
+async def say_hello():
+    await asyncio.sleep(1)
+    return {'message': 'Hello!'}
+```
+
+See <em><a href="https://flask.palletsprojects.com/en/master/async-await/">Using async and await</a></em> for the details of the async support in Flask 2.0.
+
 </details>
 
 Save this as `app.py`, then run it with :

--- a/apiflask/decorators.py
+++ b/apiflask/decorators.py
@@ -265,6 +265,9 @@ def output(
                 },
             }
             ```
+    *Version changed: 0.6.0*
+
+    - Support decorating async views.
 
     *Version changed: 0.5.2*
 
@@ -302,7 +305,10 @@ def output(
 
         @wraps(f)
         def _response(*args: Any, **kwargs: Any) -> ResponseType:
-            rv = f(*args, **kwargs)
+            if hasattr(current_app, 'ensure_sync'):  # pragma: no cover
+                rv = current_app.ensure_sync(f)(*args, **kwargs)
+            else:
+                rv = f(*args, **kwargs)  # for Flask < 2.0
             if isinstance(rv, Response):
                 return rv
             if not isinstance(rv, tuple):

--- a/tests/test_decorator_output.py
+++ b/tests/test_decorator_output.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import make_response
 from flask.views import MethodView
 from openapi_spec_validator import validate_spec
@@ -238,3 +239,25 @@ def test_output_response_object_directly(app, client):
     rv = client.get('/foo')
     assert rv.status_code == 200
     assert rv.json['message'] == 'hello'
+
+
+def test_output_on_async_view(app, client):
+    if not hasattr(app, 'ensure_sync'):
+        pytest.skip('This test requires Flask 2.0 or higher')
+
+    @app.get('/foo')
+    @output(FooSchema)
+    async def foo():
+        return {'id': 1, 'name': 'foo'}
+
+    rv = client.get('/foo')
+    assert rv.status_code == 200
+    assert rv.json['id'] == 1
+    assert rv.json['name'] == 'foo'
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['paths']['/foo']['get']['responses']['200']
+    assert rv.json['paths']['/foo']['get']['responses']['200'][
+        'content']['application/json']['schema']['$ref'] == '#/components/schemas/Foo'


### PR DESCRIPTION
A fix for Flask 2.0's async support.

```py
@app.get('/')
async def say_hello():
    await asyncio.sleep(1)
    return {'message': 'Hello!'}


@app.get('/pets/<int:pet_id>')
@output(PetOutSchema)
async def get_pet(pet_id):
    if pet_id > len(pets) - 1:
        abort(404)
    return pets[pet_id]
```
Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version Changed*` or `*Version Added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
