### PR TITLE
Add default parameter for get_reason_phrase

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Support using the `output` decorator on async views.
 - Add `PaginationSchema` and `pagination_builder` as basic pagination support.
 - Rename `utils` module to `helpers`.
+- Add `default` parameter for `get_reason_phrase`.
 
 
 ## Version 0.5.2

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -783,7 +783,7 @@ class APIFlask(Flask):
                         for status_code in view_func._spec.get('responses'):
                             responses[  # type: ignore
                                 status_code
-                            ] = get_reason_phrase(int(status_code))
+                            ] = get_reason_phrase(int(status_code), '')
                     for status_code, description in responses.items():  # type: ignore
                         status_code: str = str(status_code)  # type: ignore
                         if status_code in operation['responses']:

--- a/apiflask/exceptions.py
+++ b/apiflask/exceptions.py
@@ -55,7 +55,8 @@ class HTTPError(Exception):
         self.status_code = status_code
         self.detail = detail
         self.headers = headers
-        self.message = get_reason_phrase(status_code) if message is None else message
+        self.message = get_reason_phrase(status_code, 'Unknown error') \
+            if message is None else message
 
 
 class _ValidationError(HTTPError):
@@ -125,7 +126,7 @@ def _default_error_handler(
         headers: A dict of headers used in the error response.
     """
     if message is None:
-        message = get_reason_phrase(status_code)
+        message = get_reason_phrase(status_code, 'Unknown error')
     if detail is None:
         detail = {}
     body = {'detail': detail, 'message': message, 'status_code': status_code}

--- a/apiflask/helpers.py
+++ b/apiflask/helpers.py
@@ -11,13 +11,14 @@ from .types import PaginationType
 _sentinel = object()
 
 
-def get_reason_phrase(status_code: int) -> str:
+def get_reason_phrase(status_code: int, default: str = 'Unknown') -> str:
     """A helper function to get the reason phrase of the given status code.
 
     Arguments:
         status_code: A standard HTTP status code.
+        default: The default phrase to use if not found, defaults to "Unknown".
     """
-    return HTTP_STATUS_CODES.get(status_code, 'Unknown error')
+    return HTTP_STATUS_CODES.get(status_code, default)
 
 
 def pagination_builder(pagination: PaginationType, **kwargs: Any) -> dict:

--- a/apiflask/helpers.py
+++ b/apiflask/helpers.py
@@ -17,6 +17,10 @@ def get_reason_phrase(status_code: int, default: str = 'Unknown') -> str:
     Arguments:
         status_code: A standard HTTP status code.
         default: The default phrase to use if not found, defaults to "Unknown".
+
+    *Version Changed: 0.6.0*
+
+    - Add `default` parameter.
     """
     return HTTP_STATUS_CODES.get(status_code, default)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,7 +16,15 @@ def test_get_reason_phrase(code):
     elif code == 404:
         assert rv == 'Not Found'
     else:
-        assert rv == 'Unknown error'
+        assert rv == 'Unknown'
+
+
+def test_get_reason_phrase_default():
+    rv = get_reason_phrase(1234)
+    assert rv == 'Unknown'
+
+    rv = get_reason_phrase(1234, 'Unknown error')
+    assert rv == 'Unknown error'
 
 
 def test_pagination_builder(app, client):


### PR DESCRIPTION
Add a `default` parameter for `get_reason_phrase` helper, defaults to `Unknown`.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version Changed*` or `*Version Added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
