### PR TITLE
Fix static request dispatch for Flask 2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,15 @@
 0.7.0 plan: <https://github.com/greyli/apiflask/issues/46>
 
 
+## Version 0.6.2
+
+Released: 2021/5/16
+
+- Fix static request dispatch for Flask 2.0 ([issue #52][issue_52]).
+
+[issue_52]: https://github.com/greyli/apiflask/issues/52
+
+
 ## Version 0.6.1
 
 Released: 2021/5/15

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -320,12 +320,13 @@ class APIFlask(Flask):
         ):
             return self.make_default_options_response()  # pragma: no cover
         # otherwise dispatch to the handler for that endpoint
+        view_function = self.view_functions[rule.endpoint]
         if hasattr(self, 'ensure_sync'):  # pragma: no cover
-            return self.ensure_sync(  # type: ignore
-                self.view_functions[rule.endpoint]
-            )(*req.view_args.values())
-        else:  # pragma: no cover
-            return self.view_functions[rule.endpoint](*req.view_args.values())  # type: ignore
+            view_function = self.ensure_sync(view_function)
+        if rule.endpoint.endswith('static'):
+            return view_function(**req.view_args)  # type: ignore
+        else:
+            return view_function(*req.view_args.values())  # type: ignore
 
     def error_processor(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -144,3 +144,8 @@ def test_skip_raw_blueprint(app, client):
     assert '/bar' not in rv.json['paths']
     assert '/baz' in rv.json['paths']
     assert '/spam' in rv.json['paths']
+
+
+def test_dispatch_static_request(client):
+    rv = client.get('/static/hello.css')
+    assert rv.status_code == 404


### PR DESCRIPTION
In Flask 2.0, the static route expects a keyword argument for filename/path.

- fixes #52

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Run `pytest` and `tox`, no tests failed.
