### PR TITLE
Support using async error processor and spec processor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 0.7.0 plan: <https://github.com/greyli/apiflask/issues/46>
 
+- Support using async error processor and async spec processor
+([pull #57][pull_57]).
+
+[pull_54]: https://github.com/greyli/apiflask/pull/57
+
 
 ## Version 0.6.3
 

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -405,6 +405,10 @@ class APIFlask(Flask):
         However, I would recommend keeping the `detail` in the response since it contains
         the detailed information about the validation error when the validation error
         happened.
+
+        *Version Changed: 0.7.0*
+
+        - Support registering an async callback function.
         """
         if hasattr(self, 'ensure_sync'):  # pragma: no cover
             self.error_callback = self.ensure_sync(f)
@@ -503,6 +507,10 @@ class APIFlask(Flask):
 
         - `'json'` -> dict
         - `'yaml'` -> string
+
+        *Version Changed: 0.7.0*
+
+        - Support registering an async callback function.
         """
         if hasattr(self, 'ensure_sync'):  # pragma: no cover
             self.spec_callback = self.ensure_sync(f)


### PR DESCRIPTION
Example:

```python
@app.error_processor
async def custom_error_processor(status_code, message, detail, headers):
    return {'foo': 'test'}, status_code, headers
```

Also rewrite some docstring.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version Changed*` or `*Version Added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
