### PR TITLE
Fix auto-tag support for nesting blueprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,10 @@
 
 - Support using async error processor and async spec processor
 ([pull #57][pull_57]).
+- Fix auto-tag support for nesting blueprint ([pull #58][pull_58]).
 
-[pull_54]: https://github.com/greyli/apiflask/pull/57
+[pull_57]: https://github.com/greyli/apiflask/pull/57
+[pull_58]: https://github.com/greyli/apiflask/pull/58
 
 
 ## Version 0.6.3

--- a/apiflask/app.py
+++ b/apiflask/app.py
@@ -658,7 +658,7 @@ class APIFlask(Flask):
                 continue
             blueprint_name: t.Optional[str] = None  # type: ignore
             if '.' in rule.endpoint:
-                blueprint_name: str = rule.endpoint.split('.', 1)[0]  # type: ignore
+                blueprint_name: str = rule.endpoint.rsplit('.', 1)[0]  # type: ignore
                 blueprint = self.blueprints[blueprint_name]  # type: ignore
                 if not hasattr(blueprint, 'enable_openapi') or \
                    not blueprint.enable_openapi:  # type: ignore


### PR DESCRIPTION
With this PR, the endpoints in the child blueprint will be tagged with the correct name:

![image](https://user-images.githubusercontent.com/12967000/120264141-bf64b880-c2cf-11eb-9d62-bcaadaab5fdf.png)

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Run `pytest` and `tox`, no tests failed.
