### PR TITLE
Add `flask sepc` command to output the spec to stdout or file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,13 @@
 - Fix auto-tag support for nesting blueprint ([pull #58][pull_58]).
 - Support set the url prefix of the OpenAPI blueprint with the 
 `openapi_blueprint_url_prefix` argument ([pull #64][pull_64]).
+- Add `flask spec` command to output the OpenAPI spec to stdout
+or a file ([pull #66][pull_66]).
 
 [pull_57]: https://github.com/greyli/apiflask/pull/57
 [pull_58]: https://github.com/greyli/apiflask/pull/58
 [pull_64]: https://github.com/greyli/apiflask/pull/64
+[pull_66]: https://github.com/greyli/apiflask/pull/66
 
 
 ## Version 0.6.3

--- a/apiflask/commands.py
+++ b/apiflask/commands.py
@@ -26,7 +26,12 @@ from flask.cli import with_appcontext
 )
 @with_appcontext
 def spec_command(format, output, indent):
-    """Output the OpenAPI spec to stdout or a file."""
+    """The command (`flask spec`) to output the OpenAPI spec to stdout or a file.
+
+    Execute `flask spec --help` to see the usage.
+
+    *Version added: 0.7.0*
+    """
     spec_format = format or current_app.config['SPEC_FORMAT']
     spec = current_app.get_spec(spec_format)
     output_path = output or current_app.config['LOCAL_SPEC_PATH']

--- a/apiflask/commands.py
+++ b/apiflask/commands.py
@@ -30,7 +30,9 @@ def spec_command(format, output, indent):
     spec_format = format or current_app.config['SPEC_FORMAT']
     spec = current_app.get_spec(spec_format)
     output_path = output or current_app.config['LOCAL_SPEC_PATH']
-    json_indent = indent or current_app.config['LOCAL_SPEC_JSON_INDENT']
+    if indent is None:
+        indent = current_app.config['LOCAL_SPEC_JSON_INDENT']
+    json_indent = None if indent == 0 else indent
 
     if spec_format == 'json':
         spec = json.dumps(spec, indent=json_indent)

--- a/apiflask/commands.py
+++ b/apiflask/commands.py
@@ -1,0 +1,44 @@
+import json
+
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+
+
+@click.command('spec')
+@click.option(
+    '--format',
+    '-f',
+    type=click.Choice(['json', 'yaml', 'yml']),
+    help='The format of the spec, defaults to SPEC_FORMAT config.'
+)
+@click.option(
+    '--output',
+    '-o',
+    type=click.Path(),
+    help='The file path to the spec file, defauts to LOCAL_SPEC_PATH config.'
+)
+@click.option(
+    '--indent',
+    '-i',
+    type=int,
+    help='The indent for JSON spec, defauts to LOCAL_SPEC_JSON_INDENT config.'
+)
+@with_appcontext
+def spec_command(format, output, indent):
+    """Output the OpenAPI spec to stdout or a file."""
+    spec_format = format or current_app.config['SPEC_FORMAT']
+    spec = current_app.get_spec(spec_format)
+    output_path = output or current_app.config['LOCAL_SPEC_PATH']
+    json_indent = indent or current_app.config['LOCAL_SPEC_JSON_INDENT']
+
+    if spec_format == 'json':
+        spec = json.dumps(spec, indent=json_indent)
+
+    # output to stdout
+    click.echo(spec)
+
+    # output to local file
+    if output_path:
+        with open(output_path, 'w') as f:
+            click.echo(spec, file=f)

--- a/apiflask/settings.py
+++ b/apiflask/settings.py
@@ -15,8 +15,12 @@ LICENSE: t.Optional[t.Dict[str, str]] = None
 SERVERS: t.Optional[t.List[t.Dict[str, str]]] = None
 EXTERNAL_DOCS: t.Optional[t.Dict[str, str]] = None
 TERMS_OF_SERVICE: t.Optional[str] = None
+# OpenAPI spec
+SPEC_FORMAT: str = 'json'
 YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'
 JSON_SPEC_MIMETYPE: str = 'application/json'
+LOCAL_SPEC_PATH: t.Optional[str] = None
+LOCAL_SPEC_JSON_INDENT: int = 2
 # Automation behavior control
 AUTO_TAGS: bool = True
 AUTO_PATH_SUMMARY: bool = True

--- a/docs/api/commands.md
+++ b/docs/api/commands.md
@@ -1,0 +1,3 @@
+# Commands
+
+::: apiflask.commands

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,62 @@ app.terms_of_service = 'http://example.com/terms/'
 ```
 
 
+### OpenAPI spec
+
+Customize the generation of the OpenAPI spec.
+
+
+#### `SPEC_FORMAT`
+
+The format of the OpenAPI spec, accepts `'json'`, `'yaml'` or `'yml'`.
+
+- Type: `str`
+- Default value: `'json'`
+- Examples:
+
+```python
+app.config['SPEC_FORMAT'] = 'yaml'
+```
+
+!!! warning "Version >= 0.7.0"
+
+    This configuration variable was added in the [version 0.7.0](/changelog/#version-070).
+
+
+#### `LOCAL_SPEC_PATH`
+
+The path to the local OpenAPI spec file.
+
+- Type: `str`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['LOCAL_SPEC_PATH'] = 'openapi.json'
+```
+
+!!! warning "Version >= 0.7.0"
+
+    This configuration variable was added in the [version 0.7.0](/changelog/#version-070).
+
+
+#### `LOCAL_SPEC_JSON_INDENT`
+
+The indent of the local OpenAPI spec in JSON format.
+
+- Type: `int`
+- Default value: `2`
+- Examples:
+
+```python
+app.config['LOCAL_SPEC_JSON_INDENT'] = 4
+```
+
+!!! warning "Version >= 0.7.0"
+
+    This configuration variable was added in the [version 0.7.0](/changelog/#version-070).
+
+
 #### `JSON_SPEC_MIMETYPE`
 
 The MIME type string for JSON OpenAPI spec response.

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,1 +1,113 @@
 # OpenAPI Generating
+
+
+## Use the `flask spec` command to output the OpenAPI spec
+
+!!! warning "Version >= 0.7.0"
+
+    This feature was added in the [version 0.7.0](/changelog/#version-070).
+
+The `flask spec` command will output the spec to stdout when you execute
+the command:
+
+```
+$ flask spec
+```
+
+See the output of `flask spec --help` for the full API reference of this
+command:
+
+```
+$ flask spec --help
+```
+
+You can skip the next three sections if you have executed the above command.
+
+
+### Output the spec to a file
+
+If you provide a path with the `--output` or `-o` option, APIFlask will write
+the spec to the given path:
+
+```
+$ flask spec --output openapi.json
+```
+
+!!! note "No such file or directory?"
+
+    If the given path does not exist, you have to create the directory by yourself,
+    then APIFlask will create the file for you.
+
+You can also set the path with the configuration variable `LOCAL_SPEC_PATH`, then the
+value will be used in `flask spec` command when the `--output/-o` option is not passed:
+
+```python
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+
+app.config['LOCAL_SPEC_PATH'] = 'openapi.json'
+```
+
+```
+$ flask spec
+```
+
+
+### Change the spec format
+
+Similarly, the spec format can be set with the `--format` or `-f` option
+(defaults to `json`):
+
+```
+$ flask spec --format json
+```
+
+You can also set the format with the configuration variable `SPEC_FORMAT` (defaults
+to `'json'`), then the value will be used in `flask spec` command when the
+`--format/-f` option is not passed:
+
+```python
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+
+app.config['SPEC_FORMAT'] = 'yaml'
+```
+
+```
+$ flask spec
+```
+
+
+### Change the indent of JSON spec
+
+For the local spec file, the indent is always for readability and easy to trace the
+changes. The indent can be set with the `--indent` or `-i` option:
+
+```
+$ flask spec --indent 4
+```
+
+You can also set the indent with the configuration variable `LOCAL_SPEC_JSON_INDENT`
+(defaults to `2`), then the value will be used in `flask spec` command when the
+`--indent/-i` option is not passed:
+
+```python
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+
+app.config['LOCAL_SPEC_JSON_INDENT'] = 4
+```
+
+```
+$ flask spec
+```
+
+!!! note "The indent of spec response (`/openapi.json`)"
+
+    When you view the spec from your browser via `/openapi.json`, if you enabled the
+    debug mode or set the configuration variable `JSONIFY_PRETTYPRINT_REGULAR` to
+    `True`. Otherwise, the JSON spec will be sent without indent to save the bandwidth
+    and speed the request.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Documentation Index: docs.md
   - Migrating from Flask: migrating.md
   - Basic Usage: usage.md
+  - OpenAPI Generating: openapi.md
   - Swagger UI and Redoc: api-docs.md
   - Configuration: configuration.md
   - Examples: examples.md
@@ -52,6 +53,7 @@ nav:
     - Route: api/route.md
     - Security: api/security.md
     - Helpers: api/helpers.md
+    - Commands: api/commands.md
   - Comparison and Motivations: comparison.md
   - Authors: authors.md
   - Changelog: changelog.md
@@ -61,7 +63,6 @@ nav:
     - Request Validating: request.md
     - Response Formatting: response.md
     - Authentication: security.md
-    - OpenAPI Generating: openapi.md
     - Tutorial: tutorial/index.md
 plugins:
   - search

--- a/setup.py
+++ b/setup.py
@@ -62,4 +62,9 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.7',
+    entry_points={
+        'flask.commands': [
+            'spec=apiflask.commands:spec_command'
+        ],
+    },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,11 @@ def client(app):
 
 
 @pytest.fixture
+def cli_runner(app):
+    return app.test_cli_runner()
+
+
+@pytest.fixture
 def test_apps(monkeypatch):
     monkeypatch.syspath_prepend(
         os.path.abspath(os.path.join(os.path.dirname(__file__), 'test_apps'))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,56 @@
+import json
+
+import pytest
+from apiflask.commands import spec_command
+
+
+def test_flask_spec_stdout(app, cli_runner):
+    result = cli_runner.invoke(spec_command)
+    assert 'openapi' in result.output
+    assert json.loads(result.output) == app._spec
+
+
+def test_flask_spec_output(app, cli_runner, tmp_path):
+    local_spec_path = tmp_path / 'openapi.json'
+    result = cli_runner.invoke(spec_command, ['--output', str(local_spec_path)])
+    assert 'openapi' in result.output
+    with open(local_spec_path) as f:
+        assert json.loads(f.read()) == app._spec
+
+
+@pytest.mark.parametrize('format', ['json', 'yaml', 'yml', 'foo'])
+def test_flask_spec_format(app, cli_runner, format, tmp_path):
+    local_spec_path = tmp_path / 'openapi.json'
+
+    @app.get('/')
+    def hello():
+        pass
+
+    stdout_result = cli_runner.invoke(spec_command, ['--format', format])
+    file_result = cli_runner.invoke(
+        spec_command, ['--format', format, '--output', str(local_spec_path)]
+    )
+    if format == 'json':
+        assert '"title": "APIFlask",' in stdout_result.output
+        assert '"title": "APIFlask",' in file_result.output
+    elif format.startswith('y'):
+        assert 'title: APIFlask' in stdout_result.output
+        assert 'title: APIFlask' in file_result.output
+    else:
+        assert 'Invalid value' in stdout_result.output
+        assert 'Invalid value' in file_result.output
+
+
+@pytest.mark.parametrize('indent', [0, 2, 4])
+def test_flask_spec_indent(cli_runner, indent, tmp_path):
+    local_spec_path = tmp_path / 'openapi.json'
+    stdout_result = cli_runner.invoke(spec_command, ['--indent', indent])
+    file_result = cli_runner.invoke(
+        spec_command, ['--indent', indent, '--output', str(local_spec_path)]
+    )
+    if indent == 0:
+        assert '{"info": {' in stdout_result.output
+        assert '{"info": {' in file_result.output
+    else:
+        assert f'{{\n{" " * indent}"info": {{' in stdout_result.output
+        assert f'{{\n{" " * indent}"info": {{' in file_result.output

--- a/tests/test_settings_openapi_fields.py
+++ b/tests/test_settings_openapi_fields.py
@@ -1,7 +1,5 @@
 from openapi_spec_validator import validate_spec
 
-from apiflask import APIFlask
-
 
 def test_openapi_fields(app, client):
     openapi_version = '3.0.2'
@@ -61,30 +59,3 @@ def test_openapi_fields(app, client):
     assert rv.json['info']['contact'] == contact
     assert rv.json['info']['license'] == license
     assert rv.json['info']['termsOfService'] == terms_of_service
-
-
-def test_json_spec_mimetype(app, client):
-    rv = client.get('/openapi.json')
-    assert rv.status_code == 200
-    assert rv.mimetype == 'application/json'
-
-    app.config['JSON_SPEC_MIMETYPE'] = 'application/custom.json'
-
-    rv = client.get('/openapi.json')
-    assert rv.status_code == 200
-    assert rv.mimetype == 'application/custom.json'
-
-
-def test_yaml_spec_mimetype():
-    app = APIFlask(__name__, spec_path='/openapi.yaml')
-    client = app.test_client()
-
-    rv = client.get('/openapi.yaml')
-    assert rv.status_code == 200
-    assert rv.mimetype == 'text/vnd.yaml'
-
-    app.config['YAML_SPEC_MIMETYPE'] = 'text/custom.yaml'
-
-    rv = client.get('/openapi.yaml')
-    assert rv.status_code == 200
-    assert rv.mimetype == 'text/custom.yaml'

--- a/tests/test_settings_openapi_spec.py
+++ b/tests/test_settings_openapi_spec.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+from apiflask import APIFlask
+from apiflask.commands import spec_command
+
+
+def test_json_spec_mimetype(app, client):
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/json'
+
+    app.config['JSON_SPEC_MIMETYPE'] = 'application/custom.json'
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/custom.json'
+
+
+def test_yaml_spec_mimetype():
+    app = APIFlask(__name__, spec_path='/openapi.yaml')
+    client = app.test_client()
+
+    rv = client.get('/openapi.yaml')
+    assert rv.status_code == 200
+    assert rv.mimetype == 'text/vnd.yaml'
+
+    app.config['YAML_SPEC_MIMETYPE'] = 'text/custom.yaml'
+
+    rv = client.get('/openapi.yaml')
+    assert rv.status_code == 200
+    assert rv.mimetype == 'text/custom.yaml'
+
+
+def test_spec_format(app, cli_runner):
+    app.config['SPEC_FORMAT'] = 'yaml'
+
+    result = cli_runner.invoke(spec_command)
+    assert 'title: APIFlask' in result.output
+
+
+def test_local_spec_path(app, cli_runner, tmp_path):
+    local_spec_path = tmp_path / 'api.json'
+    app.config['LOCAL_SPEC_PATH'] = local_spec_path
+
+    result = cli_runner.invoke(spec_command)
+    assert 'openapi' in result.output
+    with open(local_spec_path) as f:
+        assert json.loads(f.read()) == app._spec
+
+
+@pytest.mark.parametrize('indent', [0, 2, 4])
+def test_local_spec_json_indent(app, cli_runner, indent):
+    app.config['LOCAL_SPEC_JSON_INDENT'] = indent
+
+    result = cli_runner.invoke(spec_command)
+    if indent == 0:
+        assert '{"info": {' in result.output
+    else:
+        assert f'{{\n{" " * indent}"info": {{' in result.output


### PR DESCRIPTION
```
$ flask spec --help

Usage: flask spec [OPTIONS]

  The command (`flask spec`) to output the OpenAPI spec to stdout or a file.

  Execute `flask spec --help` to see the usage.

Options:
  -f, --format [json|yaml|yml]  The format of the spec, defaults to
                                SPEC_FORMAT config.
  -o, --output PATH             The file path to the spec file, defauts to
                                LOCAL_SPEC_PATH config.
  -i, --indent INTEGER          The indent for JSON spec, defauts to
                                LOCAL_SPEC_JSON_INDENT config.
  --help                        Show this message and exit.
```


- fixes #61

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version Changed*` or `*Version Added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
