### PR TITLE
Remove support for automatic spec format detection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,17 @@
 - Support set the url prefix of the OpenAPI blueprint with the 
 `openapi_blueprint_url_prefix` argument ([pull #64][pull_64]).
 - Add `flask spec` command to output the OpenAPI spec to stdout
-or a file ([pull #66][pull_66]).
+or a file, also add new config `LOCAL_SPEC_PATH` and
+`LOCAL_SPEC_JSON_INDENT` ([issue #61][issue_61]).
+- Re-add the `SPEC_FORMAT` config. Remove the auto-detection of
+the format from `APIFlask(spec_path=...)`, now you have to set the
+format explicitly with the `SPEC_FORMAT` config ([issue #67][issue_67]).
 
 [pull_57]: https://github.com/greyli/apiflask/pull/57
 [pull_58]: https://github.com/greyli/apiflask/pull/58
 [pull_64]: https://github.com/greyli/apiflask/pull/64
-[pull_66]: https://github.com/greyli/apiflask/pull/66
+[issue_61]: https://github.com/greyli/apiflask/issues/61
+[issue_67]: https://github.com/greyli/apiflask/issues/67
 
 
 ## Version 0.6.3

--- a/apiflask/commands.py
+++ b/apiflask/commands.py
@@ -22,7 +22,7 @@ from flask.cli import with_appcontext
     '--indent',
     '-i',
     type=int,
-    help='The indent for JSON spec, defauts to LOCAL_SPEC_JSON_INDENT config.'
+    help='The indentation for JSON spec, defauts to LOCAL_SPEC_JSON_INDENT config.'
 )
 @with_appcontext
 def spec_command(format, output, indent):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,7 +349,16 @@ Customize the generation of the OpenAPI spec.
 
 #### `SPEC_FORMAT`
 
-The format of the OpenAPI spec, accepts `'json'`, `'yaml'` or `'yml'`.
+The format of the OpenAPI spec, accepts `'json'`, `'yaml'` or `'yml'`. This config
+will be used in the following conditions:
+
+- Serve the spec via the built-in route.
+- Execute `flask spec` without passing the `--format`/`-f` option.
+- Call `app.get_spec()` without passing the `spec_format` argument.
+
+!!! warning
+    The auto-detection of the format from the `APIFlask(spec_path=...)` was
+    removed in favor of this config in 0.7.0.
 
 - Type: `str`
 - Default value: `'json'`
@@ -383,7 +392,7 @@ app.config['LOCAL_SPEC_PATH'] = 'openapi.json'
 
 #### `LOCAL_SPEC_JSON_INDENT`
 
-The indent of the local OpenAPI spec in JSON format.
+The indentation of the local OpenAPI spec in JSON format.
 
 - Type: `int`
 - Default value: `2`

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,6 +1,43 @@
 # OpenAPI Generating
 
 
+## The spec format
+
+The default format of the OpenAPI spec is JSON, while YAML is also supported.
+If you want to enable the YAML support, install APIFlask with the `yaml` extra
+(it will install `PyYAML`):
+
+```
+$ pip install apiflask[yaml]
+```
+
+Now you can change the format via the `SPEC_FORMAT` config:
+
+```
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+app.config['SPEC_FORMAT'] == 'yaml'
+```
+
+This config will also control the format output by the `flask spec` command.
+
+
+## The indentation of spec
+
+When you view the spec from your browser via `/openapi.json`, if you enabled the
+debug mode or set the configuration variable `JSONIFY_PRETTYPRINT_REGULAR` to
+`True`, the indentation will set to `2`. Otherwise, the JSON spec will be sent
+without indentation and spaces to save the bandwidth and speed the request.
+
+The indentation of the local spec file is enabled by default. The default indentation
+is the default value of the `LOCAL_SPEC_JSON_INDENT` config (i.e., `2`). When you
+use the `flask spec` command, you can change the indentation with the `--indent`
+or `-i` option.
+
+The indentation of the YAML spec is always `2`, and it can't be changed for now.
+
+
 ## Use the `flask spec` command to output the OpenAPI spec
 
 !!! warning "Version >= 0.7.0"
@@ -80,18 +117,19 @@ $ flask spec
 ```
 
 
-### Change the indent of JSON spec
+### Change the indentation of JSON spec
 
-For the local spec file, the indent is always for readability and easy to trace the
-changes. The indent can be set with the `--indent` or `-i` option:
+For the local spec file, the indentation is always needed for readability and
+easy to trace the changes. The indentation can be set with the `--indent` or
+`-i` option:
 
 ```
 $ flask spec --indent 4
 ```
 
-You can also set the indent with the configuration variable `LOCAL_SPEC_JSON_INDENT`
-(defaults to `2`), then the value will be used in `flask spec` command when the
-`--indent/-i` option is not passed:
+You can also set the indentation with the configuration variable
+`LOCAL_SPEC_JSON_INDENT` (defaults to `2`), then the value will be used in
+the `flask spec` command when the `--indent/-i` option is not passed:
 
 ```python
 from apiflask import APIFlask
@@ -104,10 +142,3 @@ app.config['LOCAL_SPEC_JSON_INDENT'] = 4
 ```
 $ flask spec
 ```
-
-!!! note "The indent of spec response (`/openapi.json`)"
-
-    When you view the spec from your browser via `/openapi.json`, if you enabled the
-    debug mode or set the configuration variable `JSONIFY_PRETTYPRINT_REGULAR` to
-    `True`. Otherwise, the JSON spec will be sent without indent to save the bandwidth
-    and speed the request.

--- a/tests/test_openapi_blueprint.py
+++ b/tests/test_openapi_blueprint.py
@@ -1,3 +1,4 @@
+import pytest
 from apiflask import APIFlask
 
 
@@ -28,19 +29,13 @@ def test_spec_path(app):
     assert 'openapi.spec' not in bp_endpoints
 
 
-def test_yaml_spec():
-    app = APIFlask(__name__, spec_path='/spec.yaml')
+@pytest.mark.parametrize('spec_path', ['/spec.yaml', '/spec.yml'])
+def test_yaml_spec(spec_path):
+    app = APIFlask(__name__, spec_path=spec_path)
+    app.config['SPEC_FORMAT'] = 'yaml'
     client = app.test_client()
 
-    rv = client.get('/spec.yaml')
-    assert rv.status_code == 200
-    assert rv.headers['Content-Type'] == 'text/vnd.yaml'
-    assert b'title: APIFlask' in rv.data
-
-    app = APIFlask(__name__, spec_path='/spec.yml')
-    client = app.test_client()
-
-    rv = client.get('/spec.yml')
+    rv = client.get(spec_path)
     assert rv.status_code == 200
     assert rv.headers['Content-Type'] == 'text/vnd.yaml'
     assert b'title: APIFlask' in rv.data


### PR DESCRIPTION
- fixes #67

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version Changed*` or `*Version Added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
