### PR TITLE
Support to sync the local OpenAPI spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,12 +13,15 @@ or a file, also add new config `LOCAL_SPEC_PATH` and
 - Re-add the `SPEC_FORMAT` config. Remove the auto-detection of
 the format from `APIFlask(spec_path=...)`, now you have to set the
 format explicitly with the `SPEC_FORMAT` config ([issue #67][issue_67]).
+- Support to sync the local OpenAPI spec automatically. Add new config
+`SYNC_LOCAL_SPEC` ([issue #68][issue_68]).
 
 [pull_57]: https://github.com/greyli/apiflask/pull/57
 [pull_58]: https://github.com/greyli/apiflask/pull/58
 [pull_64]: https://github.com/greyli/apiflask/pull/64
 [issue_61]: https://github.com/greyli/apiflask/issues/61
 [issue_67]: https://github.com/greyli/apiflask/issues/67
+[issue_68]: https://github.com/greyli/apiflask/issues/68
 
 
 ## Version 0.6.3

--- a/apiflask/settings.py
+++ b/apiflask/settings.py
@@ -21,6 +21,7 @@ YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'
 JSON_SPEC_MIMETYPE: str = 'application/json'
 LOCAL_SPEC_PATH: t.Optional[str] = None
 LOCAL_SPEC_JSON_INDENT: int = 2
+SYNC_LOCAL_SPEC: t.Optional[bool] = None
 # Automation behavior control
 AUTO_TAGS: bool = True
 AUTO_PATH_SUMMARY: bool = True

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -385,6 +385,10 @@ The path to the local OpenAPI spec file.
 app.config['LOCAL_SPEC_PATH'] = 'openapi.json'
 ```
 
+!!! warning
+
+    If the path you passed is a relative path, do not put a leading slash in it.
+
 !!! warning "Version >= 0.7.0"
 
     This configuration variable was added in the [version 0.7.0](/changelog/#version-070).
@@ -400,6 +404,24 @@ The indentation of the local OpenAPI spec in JSON format.
 
 ```python
 app.config['LOCAL_SPEC_JSON_INDENT'] = 4
+```
+
+!!! warning "Version >= 0.7.0"
+
+    This configuration variable was added in the [version 0.7.0](/changelog/#version-070).
+
+
+#### `SYNC_LOCAL_SPEC`
+
+If `True`, the local spec will be in sync automatically, see the example usage at
+[Keep the local spec in sync automatically](/openapi#keep-the-local-spec-in-sync-automatically).
+
+- Type: `bool`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['SYNC_LOCAL_SPEC'] = True
 ```
 
 !!! warning "Version >= 0.7.0"

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -142,3 +142,81 @@ app.config['LOCAL_SPEC_JSON_INDENT'] = 4
 ```
 $ flask spec
 ```
+
+
+## Keep the local spec in sync automatically
+
+!!! warning "Version >= 0.7.0"
+
+    This feature was added in the [version 0.7.0](/changelog/#version-070).
+
+With the `flask spec` command, you can easily generate the spec to a local file.
+While it will be handy if the spec file is in sync with the project code.
+To achieve this, you need to set a path to the config `LOCAL_SPEC_PATH`,
+then enable the sync by setting the config `SYNC_LOCAL_SPEC` to `True`:
+
+```python
+from apiflask import APIFlask
+
+app = APIFlask(__name__)
+
+app.config['SYNC_LOCAL_SPEC'] = True
+app.config['LOCAL_SPEC_PATH'] = 'openapi.json'
+```
+
+!!! warning
+
+    If the path you passed is a relative path, do not put a leading slash in it.
+
+APIFlask will create the file at your current working directory (where you execute the
+`flask run` command). We recommend using an absolute path. For example, you can use
+`app.root_path`, which stores the absolute root path to your app module:
+
+```python
+from pathlib import Path
+
+app = APIFlask(__name__)
+app.config['SYNC_LOCAL_SPEC'] = True
+app.config['LOCAL_SPEC_PATH'] = Path(app.root_path) / 'openapi.json'
+```
+
+Or use the `os` module:
+
+```python
+import os
+
+app = APIFlask(__name__)
+app.config['SYNC_LOCAL_SPEC'] = True
+app.config['LOCAL_SPEC_PATH'] = os.path.join(app.root_path, 'openapi.json')
+```
+
+You can also find the project root path manually based on the current module's
+`__file_` variable when you are using an application factory:
+
+```python
+from pathlib import Path
+
+base_path = Path(__file__).parent
+# you may need to use the following if current module is
+# inside the application package:
+# base_path = Path(__file__).parent.parent
+
+app = APIFlask(__name__)
+app.config['SYNC_LOCAL_SPEC'] = True
+app.config['LOCAL_SPEC_PATH'] = base_path / 'openapi.json'
+```
+
+Or use the `os` module:
+
+```python
+import os
+
+base_path = os.path.dirname(__file__)
+# you may need to use the following if current module is
+# inside the application package:
+# base_path = os.path.dirname(os.path.dirname(__file__))
+
+app = APIFlask(__name__)
+app.config['SYNC_LOCAL_SPEC'] = True
+app.config['LOCAL_SPEC_PATH'] = os.path.join(base_path, 'openapi.json')
+```

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,7 +7,7 @@ from apiflask.commands import spec_command
 def test_flask_spec_stdout(app, cli_runner):
     result = cli_runner.invoke(spec_command)
     assert 'openapi' in result.output
-    assert json.loads(result.output) == app._spec
+    assert json.loads(result.output) == app.spec
 
 
 def test_flask_spec_output(app, cli_runner, tmp_path):
@@ -15,7 +15,7 @@ def test_flask_spec_output(app, cli_runner, tmp_path):
     result = cli_runner.invoke(spec_command, ['--output', str(local_spec_path)])
     assert 'openapi' in result.output
     with open(local_spec_path) as f:
-        assert json.loads(f.read()) == app._spec
+        assert json.loads(f.read()) == app.spec
 
 
 @pytest.mark.parametrize('format', ['json', 'yaml', 'yml', 'foo'])

--- a/tests/test_settings_openapi_spec.py
+++ b/tests/test_settings_openapi_spec.py
@@ -57,7 +57,7 @@ def test_local_spec_path(app, cli_runner, tmp_path):
     result = cli_runner.invoke(spec_command)
     assert 'openapi' in result.output
     with open(local_spec_path) as f:
-        assert json.loads(f.read()) == app._spec
+        assert json.loads(f.read()) == app.spec
 
 
 @pytest.mark.parametrize('indent', [0, 2, 4])


### PR DESCRIPTION
Example usage:

```python
from pathlib import Path

app = APIFlask(__name__)
app.config['SYNC_LOCAL_SPEC'] = True
app.config['LOCAL_SPEC_PATH'] = Path(app.root_path) / 'openapi.json'
```

- fixes #68 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
