### PR TITLE
Revert undocumented name changes on pre/post decorators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,13 @@ format explicitly with the `SPEC_FORMAT` config ([issue #67][issue_67]).
 - Change the default value of config `DOCS_FAVICON` to
 `'https://apiflask.com/_assets/favicon.png'`, set to `None` to disable
 the favicon. OpenAPI UI templates are move to `ui_templates.py`.
+- Revert the renames on pre/post decorators from Marshmallow ([issue #62][issue_62]).
 
 [pull_57]: https://github.com/greyli/apiflask/pull/57
 [pull_58]: https://github.com/greyli/apiflask/pull/58
 [pull_64]: https://github.com/greyli/apiflask/pull/64
 [issue_61]: https://github.com/greyli/apiflask/issues/61
+[issue_62]: https://github.com/greyli/apiflask/issues/62
 [issue_67]: https://github.com/greyli/apiflask/issues/67
 [issue_68]: https://github.com/greyli/apiflask/issues/68
 

--- a/src/apiflask/__init__.py
+++ b/src/apiflask/__init__.py
@@ -1,7 +1,7 @@
-from marshmallow import post_dump as after_dump
-from marshmallow import post_load as after_load
-from marshmallow import pre_dump as before_dump
-from marshmallow import pre_load as before_load
+from marshmallow import post_dump as post_dump
+from marshmallow import post_load as post_load
+from marshmallow import pre_dump as pre_dump
+from marshmallow import pre_load as pre_load
 from marshmallow import validates as validate
 from marshmallow import validates_schema as validate_schema
 from marshmallow import ValidationError as ValidationError


### PR DESCRIPTION
These undocumented name changes happened in #43, discussed in #62.

This PR will revert the name changes on pre/post decorators. The changes on validates* decorators are kept for now (but may revert in the future when the related docs are published):

- validates -> validate
- validates_schema -> valdiate_schema