### PR TITLE
Support overwriting response description with `doc` decorator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Released: -
 
 - Automatically add a 404 response in OpenAPI spec for routes contains URL
 variables ([issue #78][issue_78]).
+- Support using `doc(responses={<STATUS_CODE>: <DESCRIPTION>})` to overwrite
+existing response descriptions.
 
 [issue_78]: https://github.com/greyli/apiflask/issues/78
 

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -672,14 +672,15 @@ def hello():
 ### Alternative operation `responses`
 
 As described above, APIFlask will add some responses based on the decorators you added
-on the view function. Sometimes you may want to add alternative responses the view
-function will return, then you can use the `@doc(responses=...)` parameter, it accepts the
-following values:
+on the view function (200, 400, 401, 404). Sometimes you may want to add alternative
+responses the view function will return, then you can use the `@doc(responses=...)`
+parameter, it accepts the following values:
 
 - A list of status code int, for example, `[404, 418]`.
 - A dict in a format of `{<STATUS_CODE>: <DESCRIPTION>}`, this will allow you to
 set a custom description for each status, for example,
-`{404: 'Not Found', 418: 'Blah...'}`.
+`{404: 'Not Found', 418: 'Blah...'}`. If a response with the same status code is
+already exist, the existing description will be overwritten.
 
 ```python hl_lines="2"
 @app.get('/')

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -871,6 +871,10 @@ class APIFlask(Flask):
                     for status_code, description in responses.items():  # type: ignore
                         status_code: str = str(status_code)  # type: ignore
                         if status_code in operation['responses']:
+                            if not isinstance(
+                                view_func._spec.get('responses'), list
+                            ):  # pragma: no cover
+                                operation['responses'][status_code]['description'] = description
                             continue
                         if status_code.startswith('4') or status_code.startswith('5'):
                             # add error response schema for error responses

--- a/src/apiflask/decorators.py
+++ b/src/apiflask/decorators.py
@@ -368,7 +368,9 @@ def doc(
             tag name.
         tags: Similar to `tag` but accepts a list of tag names.
         responses: The other responses for this view function, accepts a dict in a format
-            of `{404: 'Not Found'}` or a list of status code (`[404, 418]`).
+            of `{404: 'Not Found'}` or a list of status code (`[404, 418]`). If pass a dict,
+            and a response with the same status code is already exist, the existing
+            description will be overwritten.
         deprecated: Flag this endpoint as deprecated in API docs.
         hide: Hide this endpoint in API docs.
 

--- a/tests/test_decorator_doc.py
+++ b/tests/test_decorator_doc.py
@@ -179,11 +179,11 @@ def test_doc_responses(app, client):
     validate_spec(rv.json)
     assert '200' in rv.json['paths']['/foo']['get']['responses']
     assert '400' in rv.json['paths']['/foo']['get']['responses']
-    # don't overwrite exist error description
+    # overwrite existing error descriptions
     assert rv.json['paths']['/foo']['get']['responses'][
-        '200']['description'] == 'Successful response'
+        '200']['description'] == 'success'
     assert rv.json['paths']['/foo']['get']['responses'][
-        '400']['description'] == 'Validation error'
+        '400']['description'] == 'bad'
     assert '404' in rv.json['paths']['/foo']['get']['responses']
     assert rv.json['paths']['/foo']['get']['responses'][
         '404']['description'] == 'not found'
@@ -229,9 +229,9 @@ def test_doc_responses_with_methodview(app, client):
     assert '400' in rv.json['paths']['/foo']['get']['responses']
     # don't overwrite exist error description
     assert rv.json['paths']['/foo']['get']['responses'][
-        '200']['description'] == 'Successful response'
+        '200']['description'] == 'success'
     assert rv.json['paths']['/foo']['get']['responses'][
-        '400']['description'] == 'Validation error'
+        '400']['description'] == 'bad'
     assert '404' in rv.json['paths']['/foo']['get']['responses']
     assert rv.json['paths']['/foo']['get']['responses'][
         '404']['description'] == 'not found'

--- a/tests/test_openapi_paths.py
+++ b/tests/test_openapi_paths.py
@@ -4,6 +4,7 @@ from .schemas import FooSchema
 from .schemas import HeaderSchema
 from .schemas import PaginationSchema
 from .schemas import QuerySchema
+from apiflask import doc
 from apiflask import input
 from apiflask import output
 
@@ -245,6 +246,11 @@ def test_auto_404_error(app, client):
     def bar():
         pass
 
+    @app.get('/baz/<int:id>')
+    @doc(responses={404: 'Pet not found'})
+    def baz():
+        pass
+
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
     validate_spec(rv.json)
@@ -252,3 +258,5 @@ def test_auto_404_error(app, client):
     assert '404' in rv.json['paths']['/bar/{id}']['get']['responses']
     assert rv.json['paths']['/bar/{id}']['get']['responses'][
         '404']['description'] == 'Not found'
+    assert rv.json['paths']['/baz/{id}']['get']['responses'][
+        '404']['description'] == 'Pet not found'


### PR DESCRIPTION
With this PR, you can overwrite the response description with the `doc` decorator:

```
@app.get('/baz/<int:id>')  # this will automatically add a 404 response with default description ("Not found")
@doc(responses={404: 'Pet not found'})  # this will overwrite the default 404 response description
def baz():
    pass
```

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
