### PR TITLE
Improve configuration variables for OpenAPI fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,13 @@ existing response descriptions.
 - Add configration variable `INFO` (and `app.info` attribute), it can be used
 to set the following info fields: `description`, `termsOfService`, `contact`,
 `license` ([issue #98][issue_98]).
+- Rename the following configuration variables ([issue #99][issue_99]).
+    - `AUTO_PATH_SUMMARY` -> `AUTO_OPERATION_SUMMARY`
+    - `AUTO_PATH_DESCRIPTION` -> `AUTO_OPERATION_DESCRIPTION`
 
 [issue_78]: https://github.com/greyli/apiflask/issues/78
 [issue_98]: https://github.com/greyli/apiflask/issues/98
+[issue_99]: https://github.com/greyli/apiflask/issues/99
 
 
 ## Version 0.7.0
@@ -233,7 +237,7 @@ Released: 2021-3-27
     - `SPEC_FORMAT`
     - `AUTO_TAGS`
     - `AUTO_DESCRIPTION`
-    - `AUTO_PATH_SUMMARY`
+    - `AUTO_OPERATION_SUMMARY`
     - `AUTO_PATH_DESCRIPTION`
     - `AUTO_200_RESPONSE`
     - `DEFAULT_2XX_DESCRIPTION`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ existing response descriptions.
 - Add configration variable `INFO` (and `app.info` attribute), it can be used
 to set the following info fields: `description`, `termsOfService`, `contact`,
 `license` ([issue #98][issue_98]).
-- Rename the following configuration variables ([issue #99][issue_99]).
+- Rename the following configuration variables ([issue #99][issue_99]):
     - `AUTO_PATH_SUMMARY` -> `AUTO_OPERATION_SUMMARY`
     - `AUTO_PATH_DESCRIPTION` -> `AUTO_OPERATION_DESCRIPTION`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,12 @@ Released: -
 variables ([issue #78][issue_78]).
 - Support using `doc(responses={<STATUS_CODE>: <DESCRIPTION>})` to overwrite
 existing response descriptions.
+- Add configration variable `INFO` (and `app.info` attribute), it can be used
+to set the following info fields: `description`, `termsOfService`, `contact`,
+`license` ([issue #98][issue_98]).
 
 [issue_78]: https://github.com/greyli/apiflask/issues/78
+[issue_98]: https://github.com/greyli/apiflask/issues/98
 
 
 ## Version 0.7.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -550,6 +550,11 @@ Enable or disable auto path summary from the name or docstring of the view funct
 app.config['AUTO_OPERATION_SUMMARY'] = False
 ```
 
+!!! warning
+
+    This variable was renamed from `AUTO_PATH_SUMMARY` to `AUTO_OPERATION_SUMMARY`
+    since version 0.8.0.
+
 
 #### `AUTO_OPERATION_DESCRIPTION`
 
@@ -567,6 +572,11 @@ Enable or disable auto path description from the docstring of the view function.
 ```python
 app.config['AUTO_OPERATION_DESCRIPTION'] = False
 ```
+
+!!! warning
+
+    This variable was renamed from `AUTO_PATH_DESCRIPTION` to `AUTO_OPERATION_DESCRIPTION`
+    since version 0.8.0.
 
 
 #### `AUTO_200_RESPONSE`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,23 +140,34 @@ app.openapi_version = '3.0.2'
     This configuration variable was added in the [version 0.4.0](/changelog/#version-040).
 
 
-#### `DESCRIPTION`
+#### `SERVERS`
 
-The description of the API (`openapi.info.description`). This configuration can also
-be configured from the `app.description` attribute.
+The server information of the API (`openapi.servers`), accepts multiple
+server dicts. This configuration can also be configured from the `app.servers`
+attribute.
 
-- Type: `str`
+- Type: `List[Dict[str, str]]`
 - Default value: `None`
 - Examples:
 
 ```python
-app.config['DESCRIPTION'] = 'Some description of my API.'
+app.config['SERVERS'] = [
+    {
+        'name': 'Production Server',
+        'url': 'http://api.example.com'
+    }
+]
 ```
 
 Or:
 
 ```python
-app.description = 'Some description of my API.'
+app.servers = [
+    {
+        'name': 'Production Server',
+        'url': 'http://api.example.com'
+    }
+]
 ```
 
 
@@ -211,6 +222,118 @@ app.tags = ['foo', 'bar', 'baz']
 ```
 
 
+#### `EXTERNAL_DOCS`
+
+The external documentation information of the API (`openapi.externalDocs`).
+This configuration can also be configured from the `app.external_docs` attribute.
+
+- Type: `Dict[str, str]`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['EXTERNAL_DOCS'] = {
+    'description': 'Find more info here',
+    'url': 'http://docs.example.com'
+}
+```
+
+Or:
+
+```python
+app.external_docs = {
+    'description': 'Find more info here',
+    'url': 'http://docs.example.com'
+}
+```
+
+
+#### `INFO`
+
+The info field of the API (`openapi.info`). This configuration can also be configured
+from the `app.info` attribute. The info object (openapi.info), it accepts a dict contains
+following info fields: `description`, `termsOfService`, `contact`, `license`. You can use
+separate configuration variables to overwrite this dict.
+
+- Type: `Dict[str, str]`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['INFO'] = {
+    'description': '...',
+    'termsOfService': 'http://example.com',
+    'contact': {
+        'name': 'API Support',
+        'url': 'http://www.example.com/support',
+        'email': 'support@example.com'
+    },
+    'license': {
+        'name': 'Apache 2.0',
+        'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+}
+```
+
+Or:
+
+```python
+app.info = {
+    'description': '...',
+    'termsOfService': 'http://example.com',
+    'contact': {
+        'name': 'API Support',
+        'url': 'http://www.example.com/support',
+        'email': 'support@example.com'
+    },
+    'license': {
+        'name': 'Apache 2.0',
+        'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+}
+```
+
+
+#### `DESCRIPTION`
+
+The description of the API (`openapi.info.description`). This configuration can also
+be configured from the `app.description` attribute.
+
+- Type: `str`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['DESCRIPTION'] = 'Some description of my API.'
+```
+
+Or:
+
+```python
+app.description = 'Some description of my API.'
+```
+
+
+#### `TERMS_OF_SERVICE`
+
+The terms of service URL of the API (`openapi.info.termsOfService`).
+This configuration can also be configured from the `app.terms_of_service` attribute.
+
+- Type: `str`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['TERMS_OF_SERVICE'] = 'http://example.com/terms/'
+```
+
+Or:
+
+```python
+app.terms_of_service = 'http://example.com/terms/'
+```
+
+
 #### `CONTACT`
 
 The contact information of the API (`openapi.info.contact`).
@@ -262,83 +385,6 @@ app.license = {
     'name': 'Apache 2.0',
     'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
 }
-```
-
-
-#### `SERVERS`
-
-The server information of the API (`openapi.servers`), accepts multiple
-server dicts. This configuration can also be configured from the `app.servers`
-attribute.
-
-- Type: `List[Dict[str, str]]`
-- Default value: `None`
-- Examples:
-
-```python
-app.config['SERVERS'] = [
-    {
-        'name': 'Production Server',
-        'url': 'http://api.example.com'
-    }
-]
-```
-
-Or:
-
-```python
-app.servers = [
-    {
-        'name': 'Production Server',
-        'url': 'http://api.example.com'
-    }
-]
-```
-
-
-#### `EXTERNAL_DOCS`
-
-The external documentation information of the API (`openapi.externalDocs`).
-This configuration can also be configured from the `app.external_docs` attribute.
-
-- Type: `Dict[str, str]`
-- Default value: `None`
-- Examples:
-
-```python
-app.config['EXTERNAL_DOCS'] = {
-    'description': 'Find more info here',
-    'url': 'http://docs.example.com'
-}
-```
-
-Or:
-
-```python
-app.external_docs = {
-    'description': 'Find more info here',
-    'url': 'http://docs.example.com'
-}
-```
-
-
-#### `TERMS_OF_SERVICE`
-
-The terms of service URL of the API (`openapi.info.termsOfService`).
-This configuration can also be configured from the `app.terms_of_service` attribute.
-
-- Type: `str`
-- Default value: `None`
-- Examples:
-
-```python
-app.config['TERMS_OF_SERVICE'] = 'http://example.com/terms/'
-```
-
-Or:
-
-```python
-app.terms_of_service = 'http://example.com/terms/'
 ```
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -533,7 +533,7 @@ app.config['AUTO_TAGS'] = False
 ```
 
 
-#### `AUTO_PATH_SUMMARY`
+#### `AUTO_OPERATION_SUMMARY`
 
 Enable or disable auto path summary from the name or docstring of the view function.
 
@@ -547,11 +547,11 @@ Enable or disable auto path summary from the name or docstring of the view funct
 - Examples:
 
 ```python
-app.config['AUTO_PATH_SUMMARY'] = False
+app.config['AUTO_OPERATION_SUMMARY'] = False
 ```
 
 
-#### `AUTO_PATH_DESCRIPTION`
+#### `AUTO_OPERATION_DESCRIPTION`
 
 Enable or disable auto path description from the docstring of the view function.
 
@@ -565,7 +565,7 @@ Enable or disable auto path description from the docstring of the view function.
 - Examples:
 
 ```python
-app.config['AUTO_PATH_DESCRIPTION'] = False
+app.config['AUTO_OPERATION_DESCRIPTION'] = False
 ```
 
 

--- a/examples/openapi/app.py
+++ b/examples/openapi/app.py
@@ -2,8 +2,13 @@ from apiflask import APIFlask, Schema, input, output, abort, doc
 from apiflask.fields import Integer, String
 from apiflask.validators import Length, OneOf
 
+# set openapi.info.title and openapi.info.version
 app = APIFlask(__name__, title='Pet API', version='1.0')
 
+# All the OpenAPI field config can be set with the corresponding attributes of the app instance:
+# app.description = '...'
+
+# openapi.info.description
 app.config['DESCRIPTION'] = '''
 The description for this API. It can be very long and **Markdown** is supported.
 
@@ -21,29 +26,48 @@ The source can be found at [examples/blueprint_tags/app.py][_blueprint_tags].
 
 [_blueprint_tags]: https://github.com/greyli/apiflask/tree/main/examples/blueprint_tags/app.py
 '''
-app.config['TAGS'] = [
-    {'name': 'Hello', 'description': 'The description of the **Hello** tag.'},
-    {'name': 'Pet', 'description': 'The description of the **Pet** tag.'}
-]
-# If you don't need to set tag "description" or tag "externalDocs", just pass a list a string:
-# app.config['TAGS'] = ['Hello', 'Pet']
 
-# All the OpenAPI field config can be set with the corresponding attributes of the app instance:
-# app.tags = ['Hello', 'Pet']
+# openapi.info.contact
 app.config['CONTACT'] = {
     'name': 'API Support',
     'url': 'https://greyli.com/en',
     'email': 'withlihui@gmail.com'
 }
+
+# openapi.info.license
 app.config['LICENSE'] = {
     'name': 'MIT',
     'url': 'https://opensource.org/licenses/MIT'
 }
-app.config['EXTERNAL_DOCS'] = {
-    'description': 'Find more info here',
-    'url': 'https://apiflask.com/docs'
-}
+
+# openapi.info.termsOfService
 app.config['TERMS_OF_SERVICE'] = 'http://example.com'
+
+# The four info fields above can be set with the INFO key:
+# app.config['INFO'] = {
+#     'description': '...',
+#     'termsOfService': 'http://example.com',
+#     'contact': {
+#         'name': 'API Support',
+#         'url': 'http://www.example.com/support',
+#         'email': 'support@example.com'
+#     },
+#     'license': {
+#          'name': 'Apache 2.0',
+#          'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+#      }
+# }
+
+# openapi.tags
+app.config['TAGS'] = [
+    {'name': 'Hello', 'description': 'The description of the **Hello** tag.'},
+    {'name': 'Pet', 'description': 'The description of the **Pet** tag.'}
+]
+
+# If you don't need to set tag "description" or tag "externalDocs", just pass a list a string:
+# app.config['TAGS'] = ['Hello', 'Pet']
+
+# openapi.servers
 app.config['SERVERS'] = [
     {
         'name': 'Development Server',
@@ -58,6 +82,12 @@ app.config['SERVERS'] = [
         'url': 'http://test.example.com'
     }
 ]
+
+# openapi.externalDocs
+app.config['EXTERNAL_DOCS'] = {
+    'description': 'Find more info here',
+    'url': 'https://apiflask.com/docs'
+}
 
 pets = [
     {'id': 0, 'name': 'Kitty', 'category': 'cat'},

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -72,9 +72,20 @@ class APIFlask(Flask):
         openapi_version: The version of OpenAPI Specification (openapi.openapi).
             This attribute can also be configured from the config with the
             `OPENAPI_VERSION` configuration key. Defaults to `'3.0.3'`.
-        description: The description of the API (openapi.info.description).
+        servers: The servers information of the API (openapi.servers), accepts
+            multiple server dicts. Example value:
+
+            ```python
+            app.servers = [
+                {
+                    'name': 'Production Server',
+                    'url': 'http://api.example.com'
+                }
+            ]
+            ```
+
             This attribute can also be configured from the config with the
-            `DESCRIPTION` configuration key. Defaults to `None`.
+            `SERVERS` configuration key. Defaults to `None`.
         tags: The list of tags of the OpenAPI spec documentation (openapi.tags),
             accepts a list of dicts. You can also pass a simple list contains the
             tag name:
@@ -97,6 +108,41 @@ class APIFlask(Flask):
 
             This attribute can also be configured from the config with the
             `TAGS` configuration key. Defaults to `None`.
+        external_docs: The external documentation information of the API
+            (openapi.externalDocs). Example:
+
+            ```python
+            app.external_docs = {
+                'description': 'Find more info here',
+                'url': 'http://docs.example.com'
+            }
+            ```
+
+            This attribute can also be configured from the config with the
+            `EXTERNAL_DOCS` configuration key. Defaults to `None`.
+        info: The info object (openapi.info), it accepts a dict contains following info fields:
+            `description`, `termsOfService`, `contact`, `license`. You can use separate
+            configuration variables to overwrite this dict. Example:
+
+            ```python
+            app.info = {
+                'description': '...',
+                'termsOfService': 'http://example.com',
+                'contact': {
+                    'name': 'API Support',
+                    'url': 'http://www.example.com/support',
+                    'email': 'support@example.com'
+                },
+                'license': {
+                    'name': 'Apache 2.0',
+                    'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+                }
+            }
+            ```
+
+        description: The description of the API (openapi.info.description).
+            This attribute can also be configured from the config with the
+            `DESCRIPTION` configuration key. Defaults to `None`.
         contact: The contact information of the API (openapi.info.contact). Example:
 
             ```python
@@ -120,32 +166,6 @@ class APIFlask(Flask):
 
             This attribute can also be configured from the config with the
             `LICENSE` configuration key. Defaults to `None`.
-        servers: The servers information of the API (openapi.servers), accepts
-            multiple server dicts. Example value:
-
-            ```python
-            app.servers = [
-                {
-                    'name': 'Production Server',
-                    'url': 'http://api.example.com'
-                }
-            ]
-            ```
-
-            This attribute can also be configured from the config with the
-            `SERVERS` configuration key. Defaults to `None`.
-        external_docs: The external documentation information of the API
-            (openapi.externalDocs). Example:
-
-            ```python
-            app.external_docs = {
-                'description': 'Find more info here',
-                'url': 'http://docs.example.com'
-            }
-            ```
-
-            This attribute can also be configured from the config with the
-            `EXTERNAL_DOCS` configuration key. Defaults to `None`.
         terms_of_service: The terms of service URL of the API
             (openapi.info.termsOfService). Example:
 
@@ -186,11 +206,12 @@ class APIFlask(Flask):
     """
 
     openapi_version: str = ConfigAttribute('OPENAPI_VERSION')  # type: ignore
-    description: t.Optional[str] = ConfigAttribute('DESCRIPTION')  # type: ignore
     tags: t.Optional[TagsType] = ConfigAttribute('TAGS')  # type: ignore
+    servers: t.Optional[t.List[t.Dict[str, str]]] = ConfigAttribute('SERVERS')  # type: ignore
+    info: t.Optional[t.Dict[str, t.Union[str, dict]]] = ConfigAttribute('INFO')  # type: ignore
+    description: t.Optional[str] = ConfigAttribute('DESCRIPTION')  # type: ignore
     contact: t.Optional[t.Dict[str, str]] = ConfigAttribute('CONTACT')  # type: ignore
     license: t.Optional[t.Dict[str, str]] = ConfigAttribute('LICENSE')  # type: ignore
-    servers: t.Optional[t.List[t.Dict[str, str]]] = ConfigAttribute('SERVERS')  # type: ignore
     external_docs: t.Optional[t.Dict[str, str]] = ConfigAttribute('EXTERNAL_DOCS')  # type: ignore
     terms_of_service: t.Optional[str] = ConfigAttribute('TERMS_OF_SERVICE')  # type: ignore
 
@@ -578,7 +599,11 @@ class APIFlask(Flask):
 
     def _make_info(self) -> dict:
         """Make OpenAPI info object."""
-        info: dict = {}
+        info: dict
+        if self.info:
+            info = self.info
+        else:
+            info = {}
         if self.contact:
             info['contact'] = self.contact
         if self.license:

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -780,10 +780,10 @@ class APIFlask(Flask):
                        not self.config['AUTO_200_RESPONSE']:
                         continue
                     if view_func._spec.get('generated_summary') and \
-                       not self.config['AUTO_PATH_SUMMARY']:
+                       not self.config['AUTO_OPERATION_SUMMARY']:
                         view_func._spec['summary'] = ''
                     if view_func._spec.get('generated_description') and \
-                       not self.config['AUTO_PATH_DESCRIPTION']:
+                       not self.config['AUTO_OPERATION_DESCRIPTION']:
                         view_func._spec['description'] = ''
                     if view_func._spec.get('hide'):
                         continue
@@ -811,7 +811,7 @@ class APIFlask(Flask):
                     operation['summary'] = view_func._spec.get('summary')
                 else:
                     # auto-generate summary from dotstring or view function name
-                    if self.config['AUTO_PATH_SUMMARY']:
+                    if self.config['AUTO_OPERATION_SUMMARY']:
                         operation['summary'] = get_path_summary(view_func)  # type: ignore
 
                 # description
@@ -819,7 +819,7 @@ class APIFlask(Flask):
                     operation['description'] = view_func._spec.get('description')
                 else:
                     # auto-generate description from dotstring
-                    if self.config['AUTO_PATH_DESCRIPTION']:
+                    if self.config['AUTO_OPERATION_DESCRIPTION']:
                         docs = (view_func.__doc__ or '').strip().split('\n')
                         if len(docs) > 1:
                             # use the remain lines of docstring as description

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -8,13 +8,14 @@ from .types import TagsType
 
 # OpenAPI fields
 OPENAPI_VERSION: str = '3.0.3'
-DESCRIPTION: t.Optional[str] = None
+SERVERS: t.Optional[t.List[t.Dict[str, str]]] = None
 TAGS: t.Optional[TagsType] = None
+EXTERNAL_DOCS: t.Optional[t.Dict[str, str]] = None
+INFO: t.Optional[t.Dict[str, t.Union[str, dict]]] = None
+DESCRIPTION: t.Optional[str] = None
+TERMS_OF_SERVICE: t.Optional[str] = None
 CONTACT: t.Optional[t.Dict[str, str]] = None
 LICENSE: t.Optional[t.Dict[str, str]] = None
-SERVERS: t.Optional[t.List[t.Dict[str, str]]] = None
-EXTERNAL_DOCS: t.Optional[t.Dict[str, str]] = None
-TERMS_OF_SERVICE: t.Optional[str] = None
 # OpenAPI spec
 SPEC_FORMAT: str = 'json'
 YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -25,8 +25,8 @@ LOCAL_SPEC_JSON_INDENT: int = 2
 SYNC_LOCAL_SPEC: t.Optional[bool] = None
 # Automation behavior control
 AUTO_TAGS: bool = True
-AUTO_PATH_SUMMARY: bool = True
-AUTO_PATH_DESCRIPTION: bool = True
+AUTO_OPERATION_SUMMARY: bool = True
+AUTO_OPERATION_DESCRIPTION: bool = True
 AUTO_200_RESPONSE: bool = True
 AUTO_404_RESPONSE: bool = True
 AUTO_VALIDATION_ERROR_RESPONSE: bool = True

--- a/tests/test_openapi_info.py
+++ b/tests/test_openapi_info.py
@@ -33,14 +33,75 @@ def test_other_info_fields(app, client):
     rv = client.get('/openapi.json')
     assert rv.status_code == 200
     validate_spec(rv.json)
-    assert rv.json['info']['description'] == 'My API'
-    assert rv.json['info']['termsOfService'] == 'http://example.com/terms/'
-    assert rv.json['info']['contact'] == {
+    assert rv.json['info']['description'] == app.description
+    assert rv.json['info']['termsOfService'] == app.terms_of_service
+    assert rv.json['info']['contact'] == app.contact
+    assert rv.json['info']['license'] == app.license
+
+
+def test_info_attribute(app, client):
+    assert app.info is None
+
+    app.info = {
+        'description': 'My API',
+        'termsOfService': 'http://example.com',
+        'contact': {
+            'name': 'API Support',
+            'url': 'http://www.example.com/support',
+            'email': 'support@example.com'
+        },
+        'license': {
+            'name': 'Apache 2.0',
+            'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+        }
+    }
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['info']['description'] == app.info['description']
+    assert rv.json['info']['termsOfService'] == app.info['termsOfService']
+    assert rv.json['info']['contact'] == app.info['contact']
+    assert rv.json['info']['license'] == app.info['license']
+
+
+def test_overwirte_info_attribute(app, client):
+    assert app.info is None
+    assert app.description is None
+    assert app.terms_of_service is None
+    assert app.contact is None
+    assert app.license is None
+
+    app.info = {
+        'description': 'Not set',
+        'termsOfService': 'Not set',
+        'contact': {
+            'name': 'Not set',
+            'url': 'Not set',
+            'email': 'Not set'
+        },
+        'license': {
+            'name': 'Not set',
+            'url': 'Not set'
+        }
+    }
+
+    app.description = 'My API'
+    app.terms_of_service = 'http://example.com/terms/'
+    app.contact = {
         'name': 'API Support',
         'url': 'http://www.example.com/support',
         'email': 'support@example.com'
     }
-    assert rv.json['info']['license'] == {
+    app.license = {
         'name': 'Apache 2.0',
         'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
     }
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['info']['description'] == app.description
+    assert rv.json['info']['termsOfService'] == app.terms_of_service
+    assert rv.json['info']['contact'] == app.contact
+    assert rv.json['info']['license'] == app.license

--- a/tests/test_settings_auto_behaviour.py
+++ b/tests/test_settings_auto_behaviour.py
@@ -29,7 +29,7 @@ def test_auto_tags(app, client):
 
 @pytest.mark.parametrize('config_value', [True, False])
 def test_auto_path_summary(app, client, config_value):
-    app.config['AUTO_PATH_SUMMARY'] = config_value
+    app.config['AUTO_OPERATION_SUMMARY'] = config_value
 
     @app.get('/foo')
     def foo():
@@ -79,7 +79,7 @@ def test_auto_path_summary(app, client, config_value):
 
 @pytest.mark.parametrize('config_value', [True, False])
 def test_auto_path_summary_with_methodview(app, client, config_value):
-    app.config['AUTO_PATH_SUMMARY'] = config_value
+    app.config['AUTO_OPERATION_SUMMARY'] = config_value
 
     @app.route('/foo')
     class Foo(MethodView):
@@ -121,7 +121,7 @@ def test_auto_path_summary_with_methodview(app, client, config_value):
 
 @pytest.mark.parametrize('config_value', [True, False])
 def test_auto_path_description(app, client, config_value):
-    app.config['AUTO_PATH_DESCRIPTION'] = config_value
+    app.config['AUTO_OPERATION_DESCRIPTION'] = config_value
 
     @app.get('/foo')
     def get_foo():

--- a/tests/test_settings_openapi_fields.py
+++ b/tests/test_settings_openapi_fields.py
@@ -59,3 +59,63 @@ def test_openapi_fields(app, client):
     assert rv.json['info']['contact'] == contact
     assert rv.json['info']['license'] == license
     assert rv.json['info']['termsOfService'] == terms_of_service
+
+
+def test_info(app, client):
+    app.config['INFO'] = {
+        'description': 'My API',
+        'termsOfService': 'http://example.com',
+        'contact': {
+            'name': 'API Support',
+            'url': 'http://www.example.com/support',
+            'email': 'support@example.com'
+        },
+        'license': {
+            'name': 'Apache 2.0',
+            'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+        }
+    }
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['info']['description'] == app.config['INFO']['description']
+    assert rv.json['info']['termsOfService'] == app.config['INFO']['termsOfService']
+    assert rv.json['info']['contact'] == app.config['INFO']['contact']
+    assert rv.json['info']['license'] == app.config['INFO']['license']
+
+
+def test_overwirte_info(app, client):
+    app.config['INFO'] = {
+        'description': 'Not set',
+        'termsOfService': 'Not set',
+        'contact': {
+            'name': 'Not set',
+            'url': 'Not set',
+            'email': 'Not set'
+        },
+        'license': {
+            'name': 'Not set',
+            'url': 'Not set'
+        }
+    }
+
+    app.config['DESCRIPTION'] = 'My API'
+    app.config['CONTACT'] = {
+        'name': 'API Support',
+        'url': 'http://www.example.com/support',
+        'email': 'support@example.com'
+    }
+    app.config['LICENSE'] = {
+        'name': 'Apache 2.0',
+        'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    }
+    app.config['TERMS_OF_SERVICE'] = 'http://example.com/terms/'
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['info']['description'] == app.config['DESCRIPTION']
+    assert rv.json['info']['termsOfService'] == app.config['TERMS_OF_SERVICE']
+    assert rv.json['info']['contact'] == app.config['CONTACT']
+    assert rv.json['info']['license'] == app.config['LICENSE']


### PR DESCRIPTION
- Add `INFO`.
- Rename the following configuration variables:
    - `AUTO_PATH_SUMMARY` -> `AUTO_OPERATION_SUMMARY`
    - `AUTO_PATH_DESCRIPTION` -> `AUTO_OPERATION_DESCRIPTION`

fixes #98, #99

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
