### PR TITLE
Support setting custom schema name resolver via the `APIFlask.schema_name_resolver` attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,11 @@ Released: -
 
 - Support base response schema customization, add config `BASE_RESPONSE_SCHEMA`
 and `BASE_RESPONSE_DATA_KEY` ([issue #65][issue_65]).
+- Support setting custom schema name resolver via the `APIFlask.schema_name_resolver`
+attribute ([issue #105][issue_105]).
 
 [issue_65]: https://github.com/greyli/apiflask/issues/65
+[issue_105]: https://github.com/greyli/apiflask/issues/105
 
 
 ## Version 0.8.0

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,48 @@
 # Schema, Fields, and Validators
 
 
+## Schema name resolver
+
+!!! warning "Version >= 0.9.0"
+
+    This feature was added in the [version 0.9.0](/changelog/#version-090).
+
+The OpenAPI schema name of each schema is resolved based on a resolver function, here is
+the default schema name resolver used in APIFlask:
+
+```python
+def schema_name_resolver(schema):
+    name = schema.__class__.__name__  # get schema class name
+    if name.endswith('Schema'):  # remove the "Schema" suffix
+        name = name[:-6] or name
+    if schema.partial:  # add a "Update" suffix for partial schema
+        name += 'Update'
+    return name
+```
+
+You can provide a custom schema name resolver by setting the `APIFlask.schema_name_resolver`
+attribute:
+
+```python hl_lines="14"
+from apiflask import APIFlask
+
+
+def my_schema_name_resolver(schema):
+    name = schema.__class__.__name__
+    if name.endswith('Schema'):
+        name = name[:-6] or name
+    if schema.partial:
+        name += 'Partial'
+    return name
+
+
+app = APIFlask(__name__)
+app.schema_name_resolver = my_schema_name_resolver
+```
+
+The schema name resolver should accept the schema object as argument and return the name.
+
+
 ## Base response schema customization
 
 !!! warning "Version >= 0.9.0"


### PR DESCRIPTION
Example usage:

```python
from apiflask import APIFlask


def my_schema_name_resolver(schema):
    name = schema.__class__.__name__
    if name.endswith('Schema'):
        name = name[:-6] or name
    if schema.partial:
        name += 'Partial'
    return name


app = APIFlask(__name__)
app.schema_name_resolver = my_schema_name_resolver
```

- fixes #105

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
