### PR TITLE
Pass an `HTTPError` instance to error processors and support registering auth error processor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,18 @@ Released: -
 and `BASE_RESPONSE_DATA_KEY` ([issue #65][issue_65]).
 - Support setting custom schema name resolver via the `APIFlask.schema_name_resolver`
 attribute ([issue #105][issue_105]).
+- Improve error handling ([issue #107][issue_107]):
+    - Authentication error now calls app error processor function when `APIFlask(json_errors=True)`.
+    The default HTTP reason phrase is used for auth errors.
+    - Always pass an `HTTPError` instance to error processors. When you set a custom error
+    processor, now you need to accept an `HTTPError` instance as argument. The `detail` and `headers`
+    attribute of the instance will be empty dict if not set.
+    - Add a `error_processor` decorator for `HTTPTokenAuth` and `HTTPBasicAuth`, it can be used
+    to register an custom error processor for auth errors.
 
 [issue_65]: https://github.com/greyli/apiflask/issues/65
 [issue_105]: https://github.com/greyli/apiflask/issues/105
+[issue_107]: https://github.com/greyli/apiflask/issues/107
 
 
 ## Version 0.8.0
@@ -183,7 +192,7 @@ Released: 2021/4/20
     - `AUTO_HTTP_ERROR_RESPONSE`
     - `AUTH_ERROR_SCHEMA`
 - Add new configuration variables `YAML_SPEC_MIMETYPE` and `JSON_SPEC_MIMETYPE` to support
-    to customize the MIME type of spec response ([pull #3][pull_3]).
+to customize the MIME type of spec response ([pull #3][pull_3]).
 - Remove configuration variable `SPEC_TYPE`.
 - Fix the support to pass an empty dict as schema for 204 response ([pull #12][pull_12]).
 - Support set multiple examples for request/response body with `@output(examples=...)`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,10 +15,10 @@ attribute ([issue #105][issue_105]).
     - Authentication error now calls app error processor function when `APIFlask(json_errors=True)`.
     The default HTTP reason phrase is used for auth errors.
     - Always pass an `HTTPError` instance to error processors. When you set a custom error
-    processor, now you need to accept an `HTTPError` instance as argument. The `detail` and `headers`
-    attribute of the instance will be empty dict if not set.
-    - Add a `error_processor` decorator for `HTTPTokenAuth` and `HTTPBasicAuth`, it can be used
-    to register an custom error processor for auth errors.
+    processor, now you need to accept an `HTTPError` instance as the argument. The `detail` and
+    `headers` attribute of the instance will be empty dict if not set.
+    - Add an `error_processor` decorator for `HTTPTokenAuth` and `HTTPBasicAuth`, it can be used
+    to register a custom error processor for auth errors.
 
 [issue_65]: https://github.com/greyli/apiflask/issues/65
 [issue_105]: https://github.com/greyli/apiflask/issues/105

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -341,7 +341,7 @@ class APIFlask(Flask):
             def handle_werkzeug_errrors(
                 error: WerkzeugHTTPException
             ) -> ResponseType:
-                error = HTTPError(error.code, error.name)
+                error = HTTPError(error.code, error.name)  # type: ignore
                 return self.error_callback(error)
 
     def dispatch_request(self) -> ResponseType:
@@ -406,8 +406,6 @@ class APIFlask(Flask):
             'message': error.message,
             'status_code': error.status_code
         }
-        if error.headers is None:
-            return body, error.status_code
         return body, error.status_code, error.headers
 
     def error_processor(

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -331,14 +331,14 @@ class APIFlask(Flask):
         - Always pass an `HTTPError` instance to error handlers.
         """
         @self.errorhandler(HTTPError)  # type: ignore
-        def handle_http_error(
+        def handle_http_errors(
             error: HTTPError
         ) -> ResponseType:
             return self.error_callback(error)
 
         if self.json_errors:
             @self.errorhandler(WerkzeugHTTPException)  # type: ignore
-            def handle_werkzeug_errrors(
+            def handle_werkzeug_errors(
                 error: WerkzeugHTTPException
             ) -> ResponseType:
                 error = HTTPError(error.code, error.name)  # type: ignore
@@ -424,7 +424,7 @@ class APIFlask(Flask):
         instance, this callback function will also be used for normal HTTP errors,
         for example, 404 and 500 errors, etc. You can still register a specific error
         handler for a specific error code or exception with the
-        `app.errorhanlder(code_or_exection)` decorator, in that case, the return
+        `app.errorhandler(code_or_exection)` decorator, in that case, the return
         value of the error handler will be used as the response when the corresponding
         error or exception happened.
 

--- a/src/apiflask/exceptions.py
+++ b/src/apiflask/exceptions.py
@@ -101,33 +101,7 @@ def abort(
         headers: A dict of headers used in the error response.
 
     *Version changed: 0.4.0*
+
     - Rename the function name from `abort_json` to `abort`.
     """
     raise HTTPError(status_code, message, detail, headers)
-
-
-def _default_error_handler(
-    status_code: int,
-    message: t.Optional[str] = None,
-    detail: t.Optional[t.Any] = None,
-    headers: t.Optional[t.Mapping[str, str]] = None
-) -> t.Union[t.Tuple[dict, int], t.Tuple[dict, int, t.Mapping[str, str]]]:
-    """The default error handler in APIFlask.
-
-    Arguments:
-        status_code: The status code of the error (4XX and 5xx).
-        message: The simple description of the error. If not provided,
-            the reason phrase of the status code will be used.
-        detail: The detailed information of the error, you can use it to
-            provide the addition information such as custom error code,
-            documentation URL, etc.
-        headers: A dict of headers used in the error response.
-    """
-    if message is None:
-        message = get_reason_phrase(status_code, 'Unknown error')
-    if detail is None:
-        detail = {}
-    body = {'detail': detail, 'message': message, 'status_code': status_code}
-    if headers is None:
-        return body, status_code
-    return body, status_code, headers

--- a/src/apiflask/exceptions.py
+++ b/src/apiflask/exceptions.py
@@ -43,6 +43,10 @@ class HTTPError(Exception):
                 provide the addition information such as custom error code,
                 documentation URL, etc.
             headers: A dict of headers used in the error response.
+
+        *Version changed: 0.9.0*
+
+        - Set `detail` and `headers` to empty dict if not set.
         """
         super().__init__()
         if status_code not in default_exceptions:
@@ -51,8 +55,8 @@ class HTTPError(Exception):
                 ' valid error status code are "4XX" and "5XX".'
             )
         self.status_code = status_code
-        self.detail = detail
-        self.headers = headers
+        self.detail = detail or {}
+        self.headers = headers or {}
         self.message = get_reason_phrase(status_code, 'Unknown error') \
             if message is None else message
 

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -5,8 +5,6 @@ from flask import g
 from flask_httpauth import HTTPBasicAuth as BaseHTTPBasicAuth
 from flask_httpauth import HTTPTokenAuth as BaseHTTPTokenAuth
 
-from .exceptions import _default_error_handler
-
 
 class _AuthBase:
     """Base class for `HTTPBasicAuth` and `HTTPBasicAuth`."""
@@ -26,9 +24,12 @@ def handle_auth_error(
 
     This handler will return JSON response when `app.json_errors` is `True` (default).
     """
+    error_message = 'Unauthorized Access'
     if current_app.json_errors:  # type: ignore
-        return _default_error_handler(status_code)
-    return 'Unauthorized Access', status_code
+        return current_app.error_callback(
+            status_code, message=error_message, detail=None, headers=None
+        )
+    return error_message, status_code
 
 
 class HTTPBasicAuth(_AuthBase, BaseHTTPBasicAuth):

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -13,7 +13,7 @@ class _AuthBase:
 
     def __init__(self, description: t.Optional[str] = None) -> None:
         self.description = description
-        self.error_handler(self._auth_error_handler)
+        self.error_handler(self._auth_error_handler)  # type: ignore
 
     @property
     def current_user(self) -> t.Union[None, t.Any]:
@@ -34,7 +34,7 @@ class _AuthBase:
         """
         error = HTTPError(status_code)
         if current_app.json_errors:  # type: ignore
-            return current_app.error_callback(error)
+            return current_app.error_callback(error)  # type: ignore
         return error.message, status_code
 
 

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -41,7 +41,7 @@ class _AuthBase:
     def error_processor(
         self,
         f: ErrorCallbackType
-    ) -> ErrorCallbackType:
+    ) -> None:
         """A decorator to register an error callback function for auth errors (401/403).
 
         The error callback function will be called when authentication errors happened.
@@ -69,7 +69,7 @@ class _AuthBase:
 
         *Version added: 0.9.0*
         """
-        self.error_handler(lambda status_code: f(HTTPError(status_code)))
+        self.error_handler(lambda status_code: f(HTTPError(status_code)))  # type: ignore
 
 
 class HTTPBasicAuth(_AuthBase, BaseHTTPBasicAuth):

--- a/src/apiflask/types.py
+++ b/src/apiflask/types.py
@@ -14,6 +14,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from .schemas import Schema  # noqa: F401
     from .security import HTTPBasicAuth  # noqa: F401
     from .security import HTTPTokenAuth  # noqa: F401
+    from .exceptions import HTTPError  # noqa: F401
 
 
 DecoratedType = t.TypeVar('DecoratedType', bound=t.Callable[..., t.Any])
@@ -31,7 +32,7 @@ ResponseType = t.Union[
     'WSGIApplication'
 ]
 SpecCallbackType = t.Callable[[t.Union[dict, str]], t.Union[dict, str]]
-ErrorCallbackType = t.Callable[[int, str, t.Any, t.Mapping[str, str]], ResponseType]
+ErrorCallbackType = t.Callable[['HTTPError'], ResponseType]
 
 DictSchemaType = t.Dict[str, t.Union['Field', type]]
 SchemaType = t.Union['Schema', t.Type['Schema'], DictSchemaType]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -96,6 +96,10 @@ def test_view_function_arguments_order(app, client):
 def test_error_callback(app, client):
     @app.error_processor
     def custom_error_handler(e):
+        assert e.status_code == 500
+        assert e.detail == {}
+        assert e.headers == {}
+        assert e.message == 'Internal Server Error'
         return {'message': 'something was wrong'}, 200
 
     @app.get('/')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -95,7 +95,7 @@ def test_view_function_arguments_order(app, client):
 
 def test_error_callback(app, client):
     @app.error_processor
-    def custom_error_handler(status_code, message, detail, headers):
+    def custom_error_handler(e):
         return {'message': 'something was wrong'}, 200
 
     @app.get('/')

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -47,8 +47,8 @@ def test_async_error_processor(app, client):
     skip_flask1(app)
 
     @app.error_processor
-    async def custom_error_processor(status_code, message, detail, headers):
-        return {'foo': 'test'}, status_code, headers
+    async def custom_error_processor(e):
+        return {'foo': 'test'}, e.status_code, e.headers
 
     rv = client.get('/foo')
     assert rv.status_code == 404

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,5 @@
 import pytest
 
-from apiflask.exceptions import _default_error_handler
 from apiflask.exceptions import abort
 from apiflask.exceptions import HTTPError
 
@@ -61,8 +60,8 @@ def test_abort(app, client, kwargs):
     {'message': 'bad', 'detail': {'location': 'json'}},
     {'message': 'bad', 'detail': {'location': 'json'}, 'headers': {'X-FOO': 'bar'}}
 ])
-def test_default_error_handler(kwargs):
-    rv = _default_error_handler(400, **kwargs)
+def test_default_error_handler(app, kwargs):
+    rv = app._error_handler(400, **kwargs)
     assert rv[1] == 400
     if 'message' not in kwargs:
         assert rv[0]['message'] == 'Bad Request'

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -61,7 +61,8 @@ def test_abort(app, client, kwargs):
     {'message': 'bad', 'detail': {'location': 'json'}, 'headers': {'X-FOO': 'bar'}}
 ])
 def test_default_error_handler(app, kwargs):
-    rv = app._error_handler(400, **kwargs)
+    error = HTTPError(400, **kwargs)
+    rv = app._error_handler(error)
     assert rv[1] == 400
     if 'message' not in kwargs:
         assert rv[0]['message'] == 'Bad Request'

--- a/tests/test_openapi_basic.py
+++ b/tests/test_openapi_basic.py
@@ -104,8 +104,7 @@ def test_spec_schemas(app):
     def schema():
         pass
 
-    with app.app_context():
-        spec = app.spec
+    spec = app.spec
     assert len(spec['components']['schemas']) == 5
     assert 'FooUpdate' in spec['components']['schemas']
     assert 'Bar' in spec['components']['schemas']

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -32,7 +32,7 @@ def test_bypasss_default_auth_error_handler():
     rv = app.test_client().get('/foo')
     assert rv.status_code == 401
     assert rv.headers['Content-Type'] == 'text/html; charset=utf-8'
-    assert b'Unauthorized Access' in rv.data
+    assert b'Unauthorized' in rv.data
     assert 'WWW-Authenticate' in rv.headers
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -36,6 +36,49 @@ def test_bypasss_default_auth_error_handler():
     assert 'WWW-Authenticate' in rv.headers
 
 
+def test_custom_auth_error_handler(app, client):
+    auth = HTTPTokenAuth()
+
+    @auth.error_handler
+    def handle_auth_error(status_code):
+        return 'auth error', status_code
+
+    @app.route('/foo')
+    @auth_required(auth)
+    def foo():
+        pass
+
+    rv = client.get('/foo')
+    assert rv.status_code == 401
+    assert rv.headers['Content-Type'] == 'text/html; charset=utf-8'
+    assert b'auth error' in rv.data
+    assert 'WWW-Authenticate' in rv.headers
+
+
+def test_auth_error_processor(app, client):
+    auth = HTTPTokenAuth()
+
+    @auth.error_processor
+    def auth_error_processor(e):
+        assert e.status_code == 401
+        assert e.message == 'Unauthorized'
+        assert e.detail == {}
+        assert e.headers == {}
+        return {'message': 'custom auth error message'}, e.status_code
+
+    @app.route('/foo')
+    @auth_required(auth)
+    def foo():
+        pass
+
+    rv = client.get('/foo')
+    assert rv.status_code == 401
+    assert rv.headers['Content-Type'] == 'application/json'
+    assert 'message' in rv.json
+    assert rv.json['message'] == 'custom auth error message'
+    assert 'WWW-Authenticate' in rv.headers
+
+
 def test_current_user_as_property(app, client):
     auth = HTTPBasicAuth()
 


### PR DESCRIPTION
- Authentication error now calls app error processor function when `APIFlask(json_errors=True)`. The default HTTP reason phrase is used for auth errors.
- Always pass an `HTTPError` instance to error processors. When you set a custom error processor, now you need to accept an `HTTPError` instance as the argument. The `detail` and `headers` attribute of the instance will be empty dict if not set.
- Add an `error_processor` decorator for `HTTPTokenAuth` and `HTTPBasicAuth`, it can be used to register a custom error processor for auth errors.
- Move default error handlers into class.

fixes #107

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
