### PR TITLE
Add `REDOC_CONFIG` to support config Redoc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,10 +19,12 @@ attribute ([issue #105][issue_105]).
     `headers` attribute of the instance will be empty dict if not set.
     - Add an `error_processor` decorator for `HTTPTokenAuth` and `HTTPBasicAuth`, it can be used
     to register a custom error processor for auth errors.
+- Support to config Redoc via the configuration variable `REDOC_CONFIG` ([issue #121][issue_121]).
 
 [issue_65]: https://github.com/greyli/apiflask/issues/65
 [issue_105]: https://github.com/greyli/apiflask/issues/105
 [issue_107]: https://github.com/greyli/apiflask/issues/107
+[issue_121]: https://github.com/greyli/apiflask/issues/121
 
 
 ## Version 0.8.0

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -85,6 +85,7 @@ The following configuration variables can be used to config Swagger UI/Redoc:
 
 - `DOCS_FAVICON`
 - `REDOC_USE_GOOGLE_FONT`
+- `REDOC_CONFIG`
 - `SWAGGER_UI_LAYOUT`
 - `SWAGGER_UI_CONFIG`
 - `SWAGGER_UI_OAUTH_CONFIG`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -849,6 +849,20 @@ app.config['REDOC_USE_GOOGLE_FONT'] = False
 ```
 
 
+#### `REDOC_CONFIG`
+
+The configuration options pass to Redoc. See the available options in the
+[Redoc documentation](https://github.com/Redocly/redoc#redoc-options-object).
+
+- Type: `dict`
+- Default value: `None`
+- Examples:
+
+```python
+app.config['REDOC_CONFIG'] = {'disableSearch': True, 'hideLoading': True}
+```
+
+
 #### `REDOC_STANDALONE_JS`
 
 The absolute or relative URL of the Redoc standalone JavaScript file.

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -47,6 +47,7 @@ DOCS_FAVICON: str = 'https://apiflask.com/_assets/favicon.png'
 REDOC_USE_GOOGLE_FONT: bool = True
 REDOC_STANDALONE_JS: str = 'https://cdn.jsdelivr.net/npm/redoc@next/bundles/\
 redoc.standalone.js'
+REDOC_CONFIG: t.Optional[dict] = None
 SWAGGER_UI_CSS: str = 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css'
 SWAGGER_UI_BUNDLE_JS: str = 'https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/\
 swagger-ui-bundle.js'

--- a/src/apiflask/ui_templates.py
+++ b/src/apiflask/ui_templates.py
@@ -20,8 +20,16 @@ redoc_template = '''
 </head>
 
 <body>
-  <redoc spec-url="{{ url_for('openapi.spec') }}"></redoc>
+  <div id="redoc"></div>
+
   <script src="{{ config.REDOC_STANDALONE_JS }}"> </script>
+  <script>
+    Redoc.init(
+      "{{ url_for('openapi.spec') }}",
+      {% if config.REDOC_CONFIG %}{{ config.REDOC_CONFIG | tojson }}{% else %}{}{% endif %},
+      document.getElementById("redoc")
+    )
+  </script>
 </body>
 
 </html>
@@ -65,7 +73,7 @@ swagger_ui_template = '''
   <script>
     var baseConfig = {
       url: "{{ url_for('openapi.spec') }}",
-      dom_id: '#swagger-ui',
+      dom_id: "#swagger-ui",
       deepLinking: true,
       presets: [
         SwaggerUIBundle.presets.apis,
@@ -78,7 +86,7 @@ swagger_ui_template = '''
             {% if oauth2_redirect_path %} oauth2RedirectUrl: "{{ oauth2_redirect_path }}"{% endif %}
         }
     {% if config.SWAGGER_UI_CONFIG %}
-    var userConfig = {{ config.SWAGGER_UI_CONFIG| tojson }}
+    var userConfig = {{ config.SWAGGER_UI_CONFIG | tojson }}
     for (var attr in userConfig) {
       baseConfig[attr] = userConfig[attr]
     }
@@ -87,7 +95,7 @@ swagger_ui_template = '''
       const ui = SwaggerUIBundle(baseConfig)
       {% if config.SWAGGER_UI_OAUTH_CONFIG %}
       oauthConfig = {}
-      var userOauthConfig = {{ config.SWAGGER_UI_OAUTH_CONFIG| tojson
+      var userOauthConfig = {{ config.SWAGGER_UI_OAUTH_CONFIG | tojson
     }}
     for (var attr in userOauthConfig) {
       oauthConfig[attr] = userOauthConfig[attr]

--- a/tests/test_settings_api_docs.py
+++ b/tests/test_settings_api_docs.py
@@ -26,6 +26,21 @@ def test_redoc_standalone_js(app, client):
     assert b'src="https://cdn.example.com/redoc.js"' in rv.data
 
 
+@pytest.mark.parametrize('config_value', [
+    {}, {'disableSearch': True, 'hideLoading': True}
+])
+def test_redoc_config(app, client, config_value):
+    app.config['REDOC_CONFIG'] = config_value
+
+    rv = client.get('/redoc')
+    assert rv.status_code == 200
+    if config_value == {}:
+        assert b'{},' in rv.data
+    else:
+        assert b'"disableSearch": true' in rv.data
+        assert b'"hideLoading": true' in rv.data
+
+
 def test_swagger_ui_resources(app, client):
     app.config['SWAGGER_UI_CSS'] = 'https://cdn.example.com/swagger-ui.css'
     app.config['SWAGGER_UI_BUNDLE_JS'] = 'https://cdn.example.com/swagger-ui.bundle.js'


### PR DESCRIPTION
Example:

```python
app.config['REDOC_CONFIG'] = {'disableSearch': True, 'hideLoading': True}
```

Also change the way to initialize Redoc: `<redoc></redoc>` -> `<script>Redoc.init()</script>`.

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #121

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
