### PR TITLE
Support using add_url_rule on view classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 [0.10.0 milestone](https://github.com/greyli/apiflask/milestone/6)
 
+- Support using `add_url_rule` method on view classes ([issue #110][issue_110]).
+
+[issue_110]: https://github.com/greyli/apiflask/issues/110
+
 
 ## Version 0.9.0
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -109,21 +109,11 @@ class Pet(MethodView):
         pass
 ```
 
-Beware that the view class should be registered with the `route` decorator instead of
-the `add_ul_rule()` method:
-
-```python hl_lines="1"
-@app.route('/pets/<int:pet_id>', endpoint='pet')
-class Pet(MethodView):
-    ...
-```
+APIFlask supports to use the `route` decorator on a `MethodView`-based view class as a
+shortcut, but you can also use the `add_url_rule` method to regeister it for flexibility.
 
 The `View`-based view class is not supported, you can still use it but currently
 APIFlask can't generate OpenAPI spec (and API documentation) for it.
-
-!!! tips
-
-    If the `endpoint` argument isn't provided, the class name will be used as endpoint.
 
 
 ## Other behavior changes and notes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -881,7 +881,7 @@ class Pet(MethodView):
 When creating a view class, it needs to inherit from the `MethodView` class, since APIFlask
 can only generate OpenAPI spec for `MethodView`-based view classes.:
 
-```python hl_lines="1 4"
+```python
 from flask.views import MethodView
 
 @app.route('/pets/<int:pet_id>', endpoint='pet')
@@ -891,7 +891,7 @@ class Pet(MethodView):
 
 APIFlask supports to use the `route` decorator on view classes as a shortcut for `add_url_rule`:
 
-```python hl_lines="1"
+```python
 @app.route('/pets/<int:pet_id>', endpoint='pet')
 class Pet(MethodView):
     # ...
@@ -905,7 +905,7 @@ class Pet(MethodView):
 
 Now, you can define view methods for each HTTP method, use the (HTTP) method name as method name:
 
-```python hl_lines="4 7 10 13 16"
+```python
 @app.route('/pets/<int:pet_id>', endpoint='pet')
 class Pet(MethodView):
 
@@ -940,7 +940,7 @@ app.add_url_rule('/pets/<int:pet_id>', view_func=Pet.as_view('pet'))
 ```
 
 You still don't need to set the `methods`, but you will need if you want to register multiple rules
-for one view classes based on the methods, this can only be accehived with `add_url_rule`. For
+for one view classes based on the methods, this can only be achieved with `add_url_rule`. For
 example, the `post` method you created above normally has a different URL rule than the others:
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -878,7 +878,8 @@ class Pet(MethodView):
         return '', 204
 ```
 
-When creating a view class, it needs to inherit from the `MethodView` class:
+When creating a view class, it needs to inherit from the `MethodView` class, since APIFlask
+can only generate OpenAPI spec for `MethodView`-based view classes.:
 
 ```python hl_lines="1 4"
 from flask.views import MethodView
@@ -888,7 +889,7 @@ class Pet(MethodView):
     # ...
 ```
 
-The class should be decorated with the `route` decorator:
+APIFlask supports to use the `route` decorator on view classes as a shortcut for `add_url_rule`:
 
 ```python hl_lines="1"
 @app.route('/pets/<int:pet_id>', endpoint='pet')
@@ -901,11 +902,6 @@ class Pet(MethodView):
     If the `endpoint` argument isn't provided, the class name will be used as
     endpoint. You don't need to pass a `methods` argument, since Flask will handle
     it for you.
-
-!!! warning
-
-    You should use `app.route` to register a view class instead of using
-    `app.add_url_rule` method.
 
 Now, you can define view methods for each HTTP method, use the (HTTP) method name as method name:
 
@@ -932,6 +928,29 @@ class Pet(MethodView):
 With the example application above, when the user sends a *GET* request to
 `/pets/<int:pet_id>`, the `get()` method of the `Pet` class will be called,
 and so on for the others.
+
+From [version 0.10.0](/changelog/#version-0100), you can also use the `add_url_rule` method to register
+view classes:
+
+```python
+class Pet(MethodView):
+    # ...
+
+app.add_url_rule('/pets/<int:pet_id>', view_func=Pet.as_view('pet'))
+```
+
+You still don't need to set the `methods`, but you will need if you want to register multiple rules
+for one view classes based on the methods, this can only be accehived with `add_url_rule`. For
+example, the `post` method you created above normally has a different URL rule than the others:
+
+```python
+class Pet(MethodView):
+    # ...
+
+pet_view = Pet.as_view('pet')
+app.add_url_rule('/pets/<int:pet_id>', view_func=pet_view, methods=['GET', 'PUT', 'DELETE', 'PATCH'])
+app.add_url_rule('/pets', view_func=pet_view, methods=['POST'])
+```
 
 When you use decorators like `@input`, `@output`, be sure to use it on method
 instead of class:

--- a/src/apiflask/route.py
+++ b/src/apiflask/route.py
@@ -4,56 +4,88 @@ from flask.views import MethodViewType
 
 from .openapi import get_path_description
 from .openapi import get_path_summary
+from .types import ViewClassType
+from .types import ViewFuncOrClassType
+from .types import ViewFuncType
 
 
 def route_patch(cls):
-    """A decorator to add a patched `route` decorator for `APIFlask` and
+    """A decorator to add a patched `add_url_rule` method for `APIFlask` and
     `APIBlueprint` objects.
 
-    *Version Added: 0.5.0*
-    """
-    def route(self, rule: str, **options):
-        """Decorate a view function or `MethodView` subclass to register it with
-        the given URL rule and options.
-        """
-        def decorator(f):
-            endpoint: str = options.pop('endpoint', f.__name__)
-            if isinstance(f, MethodViewType):
-                # MethodView class
-                view_func = f.as_view(endpoint)
-                if hasattr(self, 'enable_openapi') and self.enable_openapi:
-                    view_func._method_spec = {}
-                    if not hasattr(view_func, '_spec'):
-                        view_func._spec = {}
-                    for method_name in f.methods:  # method_name: ['GET', 'POST', ...]
-                        method = f.__dict__[method_name.lower()]
-                        # collect spec info from class attribute "decorators"
-                        if hasattr(view_func, '_spec') and view_func._spec != {}:
-                            if not hasattr(method, '_spec'):
-                                method._spec = view_func._spec
-                            else:
-                                for key, value in view_func._spec.items():
-                                    if value is not None and method._spec.get(key) is None:
-                                        method._spec[key] = value
-                        else:
-                            if not hasattr(method, '_spec'):
-                                method._spec = {'no_spec': True}
-                        if not method._spec.get('summary'):
-                            method._spec['summary'] = get_path_summary(
-                                method, f'{method_name.title()} {f.__name__}'
-                            )
-                            method._spec['generated_summary'] = True
-                        if not method._spec.get('description'):
-                            method._spec['description'] = get_path_description(method)
-                            method._spec['generated_description'] = True
-                        view_func._method_spec[method_name] = method._spec
-            else:
-                view_func = f
-            self.add_url_rule(rule, endpoint, view_func, **options)
-            return f
-        return decorator
+    The patched `add_url_rule` method will create a view function if passed a
+    view class, and then generate spec from it.
 
-    cls.route = route
+    *Version changed: 0.10.0*
+
+    - Remove the `route` decorator, and move the logic into `add_url_rule`.
+
+    *Version added: 0.5.0*
+    """
+    def record_spec_for_view_class(
+        view_func: ViewFuncType,
+        view_class: ViewClassType
+    ) -> ViewFuncType:
+        view_func._method_spec = {}
+        if not hasattr(view_func, '_spec'):
+            view_func._spec = {}
+        for method_name in view_class.methods:  # type: ignore
+            # method_name: ['GET', 'POST', ...]
+            method = view_class.__dict__[method_name.lower()]
+            # collect spec info from class attribute "decorators"
+            if hasattr(view_func, '_spec') and view_func._spec != {}:
+                if not hasattr(method, '_spec'):
+                    method._spec = view_func._spec
+                else:
+                    for key, value in view_func._spec.items():
+                        if value is not None and method._spec.get(key) is None:
+                            method._spec[key] = value
+            else:
+                if not hasattr(method, '_spec'):
+                    method._spec = {'no_spec': True}
+            if not method._spec.get('summary'):
+                method._spec['summary'] = get_path_summary(
+                    method, f'{method_name.title()} {view_class.__name__}'
+                )
+                method._spec['generated_summary'] = True
+            if not method._spec.get('description'):
+                method._spec['description'] = get_path_description(method)
+                method._spec['generated_description'] = True
+            view_func._method_spec[method_name] = method._spec
+        return view_func
+
+    def add_url_rule(
+        self,
+        rule: str,
+        endpoint: t.Optional[str] = None,
+        view_func: t.Optional[ViewFuncOrClassType] = None,
+        **options: t.Any,
+    ):
+        """Record the spec for view classes before calling the actual `add_url_rule` method.
+
+        The `view_func` argument can be view function, view class or `ViewClass.as_view()`.
+        """
+        view_class: ViewClassType
+        is_view_class: bool = False
+
+        if hasattr(view_func, 'view_class'):
+            # MethodViewClass.as_view()
+            is_view_class = True
+            view_class = view_func.view_class  # type: ignore
+        elif isinstance(view_func, MethodViewType):
+            # MethodView class
+            is_view_class = True
+            view_class = view_func  # type: ignore
+            if endpoint is None:
+                endpoint = view_class.__name__
+            view_func = view_class.as_view(endpoint)
+
+        if is_view_class and hasattr(self, 'enable_openapi') and self.enable_openapi:
+            view_func = record_spec_for_view_class(view_func, view_class)  # type: ignore
+
+        super(cls, self).add_url_rule(rule, endpoint, view_func, **options)
+
+    cls.add_url_rule = add_url_rule
     return cls
 
 
@@ -78,11 +110,11 @@ def route_shortcuts(cls):
         return 'Hello!'
     ```
 
-    *Version added: 0.2.0*
-
     *Version changed: 0.3.0*
 
     - Turn base class into a class decorator.
+
+    *Version added: 0.2.0*
     """
     cls_route = cls.route
 

--- a/src/apiflask/route.py
+++ b/src/apiflask/route.py
@@ -26,6 +26,11 @@ def route_patch(cls):
         view_func: ViewFuncType,
         view_class: ViewClassType
     ) -> ViewFuncType:
+        # when the user call add_url_rule multiple times for one view class,
+        # we only need to extract info from view class once since it will
+        # loop all the methods of the class.
+        if hasattr(view_func, '_method_spec'):
+            return view_func
         view_func._method_spec = {}
         if not hasattr(view_func, '_spec'):
             view_func._spec = {}

--- a/src/apiflask/route.py
+++ b/src/apiflask/route.py
@@ -63,17 +63,19 @@ def route_patch(cls):
     ):
         """Record the spec for view classes before calling the actual `add_url_rule` method.
 
-        The `view_func` argument can be view function, view class or `ViewClass.as_view()`.
+        When calling this method directly, the `view_func` argument can be a view function or
+        a view function created by `ViewClass.as_view()`. It only accepts a view class when
+        using the route decorator on a view class.
         """
         view_class: ViewClassType
         is_view_class: bool = False
 
         if hasattr(view_func, 'view_class'):
-            # MethodViewClass.as_view()
+            # a function returned by MethodViewClass.as_view()
             is_view_class = True
             view_class = view_func.view_class  # type: ignore
         elif isinstance(view_func, MethodViewType):
-            # MethodView class
+            # a MethodView class passed with the route decorator
             is_view_class = True
             view_class = view_func  # type: ignore
             if endpoint is None:

--- a/src/apiflask/types.py
+++ b/src/apiflask/types.py
@@ -8,6 +8,7 @@ else:  # pragma: no cover
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.wrappers import Response  # noqa: F401
+    from flask.views import View  # noqa: F401
     from werkzeug.datastructures import Headers  # noqa: F401
     from wsgiref.types import WSGIApplication  # noqa: F401
     from .fields import Field  # noqa: F401
@@ -39,6 +40,8 @@ SchemaType = t.Union['Schema', t.Type['Schema'], DictSchemaType]
 OpenAPISchemaType = t.Union['Schema', t.Type['Schema'], dict]
 HTTPAuthType = t.Union['HTTPBasicAuth', 'HTTPTokenAuth']
 TagsType = t.Union[t.List[str], t.List[t.Dict[str, t.Any]]]
+ViewClassType = t.Type['View']
+ViewFuncOrClassType = t.Union[t.Callable, ViewClassType]
 
 
 class PaginationType(Protocol):


### PR DESCRIPTION
This PR enables to register a view class (MethodView) with the `add_url_rule` method. APIFlask will record the OpenAPI spec info before calling the actual `add_url_rule` method.

- fixes #110

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
