### PR TITLE
Support setting OpenAPI response links via `@output(links=...)`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,13 @@
 - Remove the `status_code` field from the default error response ([issue #124][issue_124]).
 - Support passing `operation_id` in the `doc` decorator. The auo-generating of operationId
   can be enabled with config `AUTO_OPERATION_ID`, defaults to `False` ([pull #131][pull_131]).
+- Support setting response links via `@output(links=...)` ([issue #138][issue_138]).
 
 [issue_110]: https://github.com/greyli/apiflask/issues/110
 [issue_62]: https://github.com/greyli/apiflask/issues/62
 [issue_124]: https://github.com/greyli/apiflask/issues/124
 [pull_131]: https://github.com/greyli/apiflask/pull/131
+[issue_138]: https://github.com/greyli/apiflask/issues/138
 
 
 ## Version 0.9.0

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -656,6 +656,51 @@ def get_pets():
     ```
 
 
+## Response `links`
+
+You can pass the links with `links` keyword in the `output` decorator:
+
+```python
+pet_links = {
+    'getAddressByUserId': {
+        'operationId': 'getUserAddress',
+        'parameters': {
+            'userId': '$request.path.id'
+        }
+    }
+}
+
+@app.post('/pets')
+@output(PetOutSchem, links=pet_links)
+def new_pet(data):
+    pass
+```
+
+Or you can also add links to components then reference it in operation:
+
+```python
+links = {
+    'getAddressByUserId': {
+        'operationId': 'getUserAddress',
+        'parameters': {
+            'userId': '$request.path.id'
+        }
+    }
+}
+
+@app.spec_processor
+def update_spec(spec):
+    spec['components']['links'] = links
+    return spec
+
+
+@app.post('/pets')
+@output(PetOutSchem, links={'getAddressByUserId': {'$ref': '#/components/links/getAddressByUserId'}})
+def new_pet(data):
+    pass
+```
+
+
 ## Use the `doc` decorator
 
 There is also a `doc` decorator that can be used to set operation fields explicitly.

--- a/examples/openapi/app.py
+++ b/examples/openapi/app.py
@@ -129,8 +129,8 @@ def say_hello():
 
 
 @app.get('/pets/<int:pet_id>')
-@doc(tag='Pet')
 @output(PetOutSchema, description='The pet with given ID')
+@doc(tag='Pet', operation_id='getPet')
 def get_pet(pet_id):
     """Get a Pet
 
@@ -154,7 +154,17 @@ def get_pets():
 
 @app.post('/pets')
 @input(PetInSchema)
-@output(PetOutSchema, 201, description='The pet you just created')
+@output(
+    PetOutSchema,
+    201,
+    description='The pet you just created',
+    links={'getPetById': {
+        'operationId': 'getPet',
+        'parameters': {
+            'pet_id': '$response.body#/id'
+        }
+    }}
+)
 @doc(tag='Pet')
 def create_pet(data):
     """Create a Pet

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -711,6 +711,7 @@ class APIFlask(Flask):
         *Version changed: 0.10.0*
 
         - Add support for `operationId`.
+        - Add support for response `links`.
 
         *Version changed: 0.9.0*
 
@@ -946,8 +947,9 @@ class APIFlask(Flask):
                         self.config['SUCCESS_DESCRIPTION']
                     example = view_func._spec.get('response')['example']
                     examples = view_func._spec.get('response')['examples']
+                    links = view_func._spec.get('response')['links']
                     add_response(
-                        operation, status_code, schema, description, example, examples
+                        operation, status_code, schema, description, example, examples, links
                     )
                 else:
                     # add a default 200 response for views without using @output

--- a/src/apiflask/decorators.py
+++ b/src/apiflask/decorators.py
@@ -209,7 +209,8 @@ def output(
     description: t.Optional[str] = None,
     schema_name: t.Optional[str] = None,
     example: t.Optional[t.Any] = None,
-    examples: t.Optional[t.Dict[str, t.Any]] = None
+    examples: t.Optional[t.Dict[str, t.Any]] = None,
+    links: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> t.Callable[[DecoratedType], DecoratedType]:
     """Add output settings for view functions.
 
@@ -260,6 +261,26 @@ def output(
                 },
             }
             ```
+        links: The `links` of response. It accepts a dict which maps a link name to
+            a link object. Example:
+
+            ```python
+            {
+                'getAddressByUserId': {
+                    'operationId': 'getUserAddress',
+                    'parameters': {
+                        'userId': '$request.path.id'
+                    }
+                }
+            }
+            ```
+
+            See the [docs](https://apiflask.com/openapi/#response-links) for more details
+            about setting response links.
+
+    *Version changed: 0.10.0*
+
+    - Add `links` parameter.
 
     *Version changed: 0.9.0*
 
@@ -293,7 +314,8 @@ def output(
             'status_code': status_code,
             'description': description,
             'example': example,
-            'examples': examples
+            'examples': examples,
+            'links': links,
         })
 
         def _jsonify(

--- a/src/apiflask/openapi.py
+++ b/src/apiflask/openapi.py
@@ -20,7 +20,8 @@ default_response = {
     'status_code': 200,
     'description': None,
     'example': None,
-    'examples': None
+    'examples': None,
+    'links': None,
 }
 
 
@@ -148,8 +149,14 @@ def add_response(
     description: str,
     example: t.Optional[t.Any] = None,
     examples: t.Optional[t.Dict[str, t.Any]] = None,
+    links: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> None:
-    """Add response to operation."""
+    """Add response to operation.
+
+    *Version changed: 0.10.0*
+
+    - Add `links` parameter.
+    """
     operation['responses'][status_code] = {}
     if status_code != '204':
         operation['responses'][status_code]['content'] = {
@@ -164,6 +171,8 @@ def add_response(
     if examples is not None:
         operation['responses'][status_code]['content'][
             'application/json']['examples'] = examples
+    if links is not None:
+        operation['responses'][status_code]['links'] = links
 
 
 def add_response_with_schema(


### PR DESCRIPTION
The `output` decorator now accepts a `links` argument for response links:

```py
@app.post('/pets')
@input(PetInSchema)
@output(
    PetOutSchema,
    201,
    description='The pet you just created',
    links={'getPetById': {
        'operationId': 'getPet',
        'parameters': {
            'pet_id': '$response.body#/id'
        }
    }}
)
@doc(tag='Pet')
def create_pet(data):
    ...
```

- fixes #138


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
