### PR TITLE
Add custom error classes support for HTTPError

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 [0.11.0 milestone](https://github.com/greyli/apiflask/milestone/7)
 
+- Support creating custom error classes based on `HTTPError`. The position argument `status_code` of
+  `HTTPError` is changed to a keyword argument, defaults to `500`.([issue #172][issue_172]).
+
+[issue_172]: https://github.com/greyli/apiflask/issues/172
+
 
 ## Version 0.10.1
 

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -329,7 +329,7 @@ class APIFlask(Flask):
 
         - Always pass an `HTTPError` instance to error handlers.
         """
-        @self.errorhandler(HTTPError)  # type: ignore
+        @self.errorhandler(HTTPError)
         def handle_http_errors(
             error: HTTPError
         ) -> ResponseReturnValueType:

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -34,7 +34,7 @@ from .helpers import get_reason_phrase
 from .route import route_shortcuts
 from .route import route_patch
 from .schemas import Schema
-from .types import ResponseType
+from .types import ResponseReturnValueType
 from .types import ViewFuncType
 from .types import ErrorCallbackType
 from .types import SpecCallbackType
@@ -315,7 +315,7 @@ class APIFlask(Flask):
         self.json_errors = json_errors
 
         self.spec_callback: t.Optional[SpecCallbackType] = None
-        self.error_callback: ErrorCallbackType = self._error_handler  # type: ignore
+        self.error_callback: ErrorCallbackType = self._error_handler
         self.schema_name_resolver = self._schema_name_resolver
 
         self._spec: t.Optional[t.Union[dict, str]] = None
@@ -329,28 +329,28 @@ class APIFlask(Flask):
 
         - Always pass an `HTTPError` instance to error handlers.
         """
-        @self.errorhandler(HTTPError)
+        @self.errorhandler(HTTPError)  # type: ignore
         def handle_http_errors(
             error: HTTPError
-        ) -> ResponseType:
+        ) -> ResponseReturnValueType:
             return self.error_callback(error)
 
         if self.json_errors:
             @self.errorhandler(WerkzeugHTTPException)  # type: ignore
             def handle_werkzeug_errors(
                 e: WerkzeugHTTPException
-            ) -> ResponseType:
+            ) -> ResponseReturnValueType:
                 headers = dict(e.get_headers())
                 # remove the original MIME header
                 del headers['Content-Type']
                 error = HTTPError(
-                    e.code,  # type: ignore
+                    e.code,
                     message=e.name,
                     headers=headers
                 )
                 return self.error_callback(error)
 
-    def dispatch_request(self) -> ResponseType:
+    def dispatch_request(self) -> ResponseReturnValueType:
         """Overwrite the default dispatch method in Flask.
 
         With this overwrite, view arguments are passed as positional
@@ -395,7 +395,7 @@ class APIFlask(Flask):
     @staticmethod
     def _error_handler(
         error: HTTPError
-    ) -> t.Union[t.Tuple[dict, int], t.Tuple[dict, int, t.Mapping[str, str]]]:
+    ) -> ResponseReturnValueType:
         """The default error handler.
 
         Arguments:
@@ -523,7 +523,7 @@ class APIFlask(Flask):
 
         if self.spec_path:
             @bp.route(self.spec_path)
-            def spec() -> ResponseType:
+            def spec() -> ResponseReturnValueType:
                 if self.config['SPEC_FORMAT'] == 'json':
                     response = jsonify(self._get_spec('json'))
                     response.mimetype = self.config['JSON_SPEC_MIMETYPE']

--- a/src/apiflask/decorators.py
+++ b/src/apiflask/decorators.py
@@ -17,7 +17,7 @@ from .types import DictSchemaType
 from .types import HTTPAuthType
 from .types import OpenAPISchemaType
 from .types import RequestType
-from .types import ResponseType
+from .types import ResponseReturnValueType
 from .types import SchemaType
 
 
@@ -341,7 +341,7 @@ def output(
             return jsonify(data, *args, **kwargs)
 
         @wraps(f)
-        def _response(*args: t.Any, **kwargs: t.Any) -> ResponseType:
+        def _response(*args: t.Any, **kwargs: t.Any) -> ResponseReturnValueType:
             if hasattr(current_app, 'ensure_sync'):  # pragma: no cover
                 rv = current_app.ensure_sync(f)(*args, **kwargs)
             else:  # pragma: no cover

--- a/src/apiflask/security.py
+++ b/src/apiflask/security.py
@@ -7,6 +7,7 @@ from flask_httpauth import HTTPTokenAuth as BaseHTTPTokenAuth
 
 from .exceptions import HTTPError
 from .types import ErrorCallbackType
+from .types import ResponseReturnValueType
 
 
 class _AuthBase:
@@ -23,7 +24,7 @@ class _AuthBase:
     @staticmethod
     def _auth_error_handler(
         status_code: int
-    ) -> t.Union[t.Tuple[str, int], t.Tuple[dict, int], t.Tuple[dict, int, t.Mapping[str, str]]]:
+    ) -> ResponseReturnValueType:
         """The default error handler for Flask-HTTPAuth.
 
         This handler will return JSON response when setting `APIFlask(json_errors=True)` (default).
@@ -36,7 +37,7 @@ class _AuthBase:
         error = HTTPError(status_code)
         if current_app.json_errors:  # type: ignore
             return current_app.error_callback(error)  # type: ignore
-        return error.message, status_code
+        return error.message, status_code  # type: ignore
 
     def error_processor(
         self,

--- a/src/apiflask/types.py
+++ b/src/apiflask/types.py
@@ -21,19 +21,25 @@ if t.TYPE_CHECKING:  # pragma: no cover
 DecoratedType = t.TypeVar('DecoratedType', bound=t.Callable[..., t.Any])
 RequestType = t.TypeVar('RequestType')
 
-_Body = t.Union[str, bytes, t.Dict[str, t.Any], t.Generator[str, None, None], 'Response']
-_Status = t.Union[str, int]
-_Header = t.Union[str, t.List[str], t.Tuple[str, ...]]
-_Headers = t.Union[t.Dict[str, _Header], t.List[t.Tuple[str, _Header]], 'Headers']
-ResponseType = t.Union[
-    _Body,
-    t.Tuple[_Body, _Status],
-    t.Tuple[_Body, _Headers],
-    t.Tuple[_Body, _Status, _Headers],
+ResponseBodyType = t.Union[str, bytes, t.Dict[str, t.Any], t.Generator[str, None, None], 'Response']
+ResponseStatusType = t.Union[str, int]
+_HeaderName = str
+_HeaderValue = t.Union[str, t.List[str], t.Tuple[str, ...]]
+ResponseHeaderType = t.Union[
+    t.Dict[_HeaderName, _HeaderValue],
+    t.Mapping[_HeaderName, _HeaderValue],
+    t.List[t.Tuple[_HeaderName, _HeaderValue]],
+    'Headers'
+]
+ResponseReturnValueType = t.Union[
+    ResponseBodyType,
+    t.Tuple[ResponseBodyType, ResponseStatusType],
+    t.Tuple[ResponseBodyType, ResponseHeaderType],
+    t.Tuple[ResponseBodyType, ResponseStatusType, ResponseHeaderType],
     'WSGIApplication'
 ]
 SpecCallbackType = t.Callable[[t.Union[dict, str]], t.Union[dict, str]]
-ErrorCallbackType = t.Callable[['HTTPError'], ResponseType]
+ErrorCallbackType = t.Callable[['HTTPError'], ResponseReturnValueType]
 
 DictSchemaType = t.Dict[str, t.Union['Field', type]]
 SchemaType = t.Union['Schema', t.Type['Schema'], DictSchemaType]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 deps = pre-commit
 skip_install = true
 commands =
-    pre-commit run --all-files --show-diff-on-failure
+    pre-commit run --all-files
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Add custom error classes support for HTTPError, the `status_code` now is a keyword argument, defaults to 500.

- fixes #172

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
