### PR TITLE
Add support for Python 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9', 'pypy-3.8']
+        python: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.8']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install --upgrade pip wheel
+      - run: python -m pip install --upgrade pip wheel setuptools
       - run: pip install tox tox-gh-actions
       - run: tox
   coverage:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/dev.in
 #
-asgiref==3.5.0
+asgiref==3.4.1
     # via -r requirements/tests.in
 astunparse==1.6.3
     # via pytkdocs

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -2,4 +2,4 @@ pytest
 pytest-cov
 flake8
 openapi-spec-validator
-asgiref
+asgiref <= 3.4.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements/tests.in
 #
-asgiref==3.5.0
+asgiref==3.4.1
     # via -r requirements/tests.in
 attrs==21.4.0
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
         Framework :: Flask
         Intended Audience :: Developers
         Programming Language :: Python :: 3 :: Only
+        Programming Language :: Python :: 3.6
         Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
@@ -35,7 +36,7 @@ classifiers =
 packages = find:
 package_dir = = src
 include_package_data = true
-python_requires = >= 3.7
+python_requires = >= 3.6
 # Dependencies are in setup.py for GitHub's dependency graph.
 
 [options.packages.find]

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     extras_require={
         'dotenv': ['python-dotenv'],
         'yaml': ['pyyaml'],
-        'async': ['asgiref >= 3.2'],
+        'async': ['asgiref >= 3.2, <= 3.4.1'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,12 @@ from setuptools import setup
 setup(
     name='APIFlask',
     install_requires=[
-        'flask >= 1.1.0',
+        'flask >= 1.1.0, <= 2.0.3',
         'flask-marshmallow >= 0.12.0',
-        'webargs >= 6',
+        'marshmallow >= 3, <= 3.14.1',
+        'webargs >= 6, <= 8',
         'flask-httpauth >= 4',
-        'apispec >= 4.2.0',
+        'apispec >= 4.2.0, <= 5.1.1',
         'typing-extensions; python_version < "3.8"',
     ],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,6 @@ commands = mypy
 deps =
     -r requirements/tests.txt
     flask == 1.1.4
+    markupsafe == 2.0.1
 commands =
     pytest -v {posargs: tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = style,py37,py38,py39,pypy38,docs,mypy,flask1
+envlist = style,py36,py37,py38,py39,pypy38,docs,mypy,flask1
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38, mypy, flask1
     3.9: py39


### PR DESCRIPTION
Try to add support for Python 3.6 version.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [ ] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [ ] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [ ] Run `pytest` and `tox`, no tests failed.
