### PR TITLE
Remove the API page of decorators

### DIFF
--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,3 +1,0 @@
-# Decorators
-
-::: apiflask.decorators


### PR DESCRIPTION
Since they have been moved to the APIFlask and APIBlueprint classes (their API docs will appear there).

This will also fix the mkdocstrings build issue ([TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'](https://app.netlify.com/sites/apiflask/deploys/621cd16584a28900076180e4)) coincidentally because the issue was caused by the typing of webargs...

- [ ] Merge this when 0.12 is about to release or the versioned doc is added.