### PR TITLE
Support customizing operation security and security schemes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,11 @@ Released: --
 - Add a base class (`apiflask.scaffold.APIScaffold`) for common logic of `APIFlask` and
   `APIBlueprint`, move route decorators and API-related decorators to this base class
   to improve the IDE auto-completion ([issue #231][issue_231]).
+- Support customizing OpenAPI securitySchemes and operation security, this makes it
+  possible to use any external authentication libraries ([pull #232][pull_232]).
 
 [issue_231]: https://github.com/greyli/apiflask/issues/231
+[pull_232]: https://github.com/greyli/apiflask/pull/232
 
 
 ## Version 0.12.0

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,1 +1,1 @@
-c# Authentication
+# Security

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,7 @@ nav:
     - Schema, Fields, and Validators: schema.md
     - Request Validating: request.md
     - Response Formatting: response.md
-    - Authentication: security.md
+    - Security: security.md
     - Tutorial: tutorial/index.md
 plugins:
   - search

--- a/src/apiflask/settings.py
+++ b/src/apiflask/settings.py
@@ -16,6 +16,7 @@ DESCRIPTION: t.Optional[str] = None
 TERMS_OF_SERVICE: t.Optional[str] = None
 CONTACT: t.Optional[t.Dict[str, str]] = None
 LICENSE: t.Optional[t.Dict[str, str]] = None
+SECURITY_SCHEMES: t.Optional[t.Dict[str, t.Any]] = None
 # OpenAPI spec
 SPEC_FORMAT: str = 'json'
 YAML_SPEC_MIMETYPE: str = 'text/vnd.yaml'

--- a/tests/test_settings_openapi_fields.py
+++ b/tests/test_settings_openapi_fields.py
@@ -119,3 +119,25 @@ def test_overwirte_info(app, client):
     assert rv.json['info']['termsOfService'] == app.config['TERMS_OF_SERVICE']
     assert rv.json['info']['contact'] == app.config['CONTACT']
     assert rv.json['info']['license'] == app.config['LICENSE']
+
+
+def test_security_shemes(app, client):
+    app.config['SECURITY_SCHEMES'] = {
+        'ApiKeyAuth': {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': 'X-API-Key'
+        },
+        'BasicAuth': {
+            'type': 'http',
+            'scheme': 'basic',
+        },
+    }
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert rv.json['components']['securitySchemes']['ApiKeyAuth'] == \
+        app.config['SECURITY_SCHEMES']['ApiKeyAuth']
+    assert rv.json['components']['securitySchemes']['BasicAuth'] == \
+        app.config['SECURITY_SCHEMES']['BasicAuth']


### PR DESCRIPTION
- Add config `SECURITY_SCHEMES` and `app.security_schemes` attribute.
- Add `security` parameter to `app.doc()`.

Example:

```python
app = APIFlask(__name__)
app.security_schemes = {
    'ApiKeyAuth': {
      'type': 'apiKey',
      'in': 'header',
      'name': 'X-API-Key',
    }
}

@app.post('/pets')
@app.input(PetInSchema)
@app.output(PetOutSchema, 201)
@app.doc(security='ApiKeyAuth')  # <--
def create_pet(data):
    pet_id = len(pets)
    data['id'] = pet_id
    pets.append(data)
    return pets[pet_id]
```

This makes it possible to use external auth libraries.

- fixes #186

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
