### PR TITLE
Support parsing and generating OpenAPI spec for file uploads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,11 +16,18 @@ Released: --
   possible to use any external authentication libraries ([pull #232][pull_232]).
 - Improve the way to detect blueprint from view endpoint to support the endpoints that
   contain dots ([issue #211][issue_211]).
+- Support file uploading ([issue #123][issue_123]):
+  - Fix the content type of `form` and `files` input locations.
+  - Raise error if the user uses multiple body input locations ("files", "form", "json").
+  - Add `Form` field and `form_and_files` location for better form upload support.
+  - Rewrite the `files` to act like `form_and_files`, so that failed parsed file will
+    be included in the returned data.
 
 [issue_211]: https://github.com/greyli/apiflask/issues/211
 [issue_231]: https://github.com/greyli/apiflask/issues/231
 [pull_232]: https://github.com/greyli/apiflask/pull/232
 [issue_237]: https://github.com/greyli/apiflask/issues/237
+[issue_123]: https://github.com/greyli/apiflask/issues/123
 
 
 ## Version 0.12.0

--- a/src/apiflask/app.py
+++ b/src/apiflask/app.py
@@ -1067,9 +1067,10 @@ class APIFlask(APIScaffold, Flask):
 
                 # requestBody
                 if view_func._spec.get('body'):
+                    content_type = view_func._spec.get('content_type', 'application/json')
                     operation['requestBody'] = {
                         'content': {
-                            'application/json': {
+                            content_type: {
                                 'schema': view_func._spec['body'],
                             }
                         }
@@ -1077,11 +1078,11 @@ class APIFlask(APIScaffold, Flask):
                     if view_func._spec.get('body_example'):
                         example = view_func._spec.get('body_example')
                         operation['requestBody']['content'][
-                            'application/json']['example'] = example
+                            content_type]['example'] = example
                     if view_func._spec.get('body_examples'):
                         examples = view_func._spec.get('body_examples')
                         operation['requestBody']['content'][
-                            'application/json']['examples'] = examples
+                            content_type]['examples'] = examples
 
                 # security
                 if custom_security:  # custom security

--- a/src/apiflask/fields.py
+++ b/src/apiflask/fields.py
@@ -34,3 +34,11 @@ from marshmallow.fields import TimeDelta as TimeDelta
 from marshmallow.fields import Tuple as Tuple
 from marshmallow.fields import URL as URL
 from marshmallow.fields import UUID as UUID
+
+
+class File(Field):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if 'type' not in self.metadata:
+            self.metadata['type'] = 'file'

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -9,6 +9,7 @@ from flask import Response
 from flask.views import MethodViewType
 from marshmallow import ValidationError as MarshmallowValidationError
 from webargs.flaskparser import FlaskParser as BaseFlaskParser
+from webargs.multidictproxy import MultiDictProxy
 
 from .exceptions import _ValidationError
 from .helpers import _sentinel
@@ -49,6 +50,13 @@ class FlaskParser(BaseFlaskParser):
 
 parser: FlaskParser = FlaskParser()
 use_args: t.Callable = parser.use_args
+
+
+@parser.location_loader('form_and_files')
+def load_form_and_files(request, schema):
+    form_and_files_data = request.files.copy()
+    form_and_files_data.update(request.form)
+    return MultiDictProxy(form_and_files_data, schema)
 
 
 def _annotate(f: t.Any, **kwargs: t.Any) -> None:
@@ -249,19 +257,42 @@ class APIScaffold:
 
         def decorator(f):
             if location not in [
-                'json', 'query', 'headers', 'cookies', 'files', 'form', 'querystring'
+                'json',
+                'query',
+                'headers',
+                'cookies',
+                'files',
+                'form',
+                'querystring',
+                'form_and_files'
             ]:
                 raise ValueError(
                     'Unknown input location. The supported locations are: "json", "files",'
-                    ' "form", "cookies", "headers", "query" (same as "querystring").'
-                    f' Got "{location}" instead.'
+                    ' "form", "cookies", "headers", "query" (same as "querystring"), and '
+                    f'"form_and_files". Got "{location}" instead.'
                 )
             if location == 'json':
                 _annotate(f, body=schema, body_example=example, body_examples=examples)
+            elif location == 'form':
+                _annotate(
+                    f,
+                    body=schema,
+                    body_example=example,
+                    body_examples=examples,
+                    content_type='application/x-www-form-urlencoded'
+                )
+            elif location in ['files', 'form_and_files']:
+                _annotate(
+                    f,
+                    body=schema,
+                    body_example=example,
+                    body_examples=examples,
+                    content_type='multipart/form-data'
+                )
             else:
                 if not hasattr(f, '_spec') or f._spec.get('args') is None:
                     _annotate(f, args=[])
-                # Todo: Support set example for request parameters
+                # TODO: Support set example for request parameters
                 f._spec['args'].append((schema, location))
             return use_args(schema, location=location, **kwargs)(f)
         return decorator

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -3,6 +3,7 @@ from marshmallow import EXCLUDE
 from apiflask import Schema
 from apiflask.fields import File
 from apiflask.fields import Integer
+from apiflask.fields import List
 from apiflask.fields import String
 
 
@@ -40,6 +41,10 @@ class FormSchema(Schema):
 
 class FilesSchema(Schema):
     image = File()
+
+
+class FilesListSchema(Schema):
+    images = List(File())
 
 
 class FormAndFilesSchema(Schema):

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -1,6 +1,7 @@
 from marshmallow import EXCLUDE
 
 from apiflask import Schema
+from apiflask.fields import File
 from apiflask.fields import Integer
 from apiflask.fields import String
 
@@ -31,6 +32,19 @@ class QuerySchema(Schema):
         unknown = EXCLUDE
 
     id = Integer(load_default=1)
+
+
+class FormSchema(Schema):
+    name = String()
+
+
+class FilesSchema(Schema):
+    image = File()
+
+
+class FormAndFilesSchema(Schema):
+    name = String()
+    image = File()
 
 
 class PaginationSchema(Schema):

--- a/tests/test_decorator_input.py
+++ b/tests/test_decorator_input.py
@@ -1,9 +1,14 @@
+import io
+
 import pytest
 from flask.views import MethodView
 from openapi_spec_validator import validate_spec
 
 from .schemas import BarSchema
+from .schemas import FilesSchema
 from .schemas import FooSchema
+from .schemas import FormAndFilesSchema
+from .schemas import FormSchema
 from .schemas import QuerySchema
 from apiflask.fields import String
 
@@ -86,6 +91,87 @@ def test_input_with_query_location(app, client):
     rv = client.post('/foo?name=bar&name2=baz')
     assert rv.status_code == 200
     assert rv.json == {'name': 'bar', 'name2': 'baz'}
+
+
+def test_input_with_form_location(app, client):
+    @app.post('/')
+    @app.input(FormSchema, location='form')
+    def index(form_data):
+        return form_data
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    validate_spec(rv.json)
+    assert 'application/x-www-form-urlencoded' in rv.json['paths']['/']['post']['requestBody'][
+        'content']
+    assert rv.json['paths']['/']['post']['requestBody']['content'][
+        'application/x-www-form-urlencoded']['schema']['$ref'] == '#/components/schemas/Form'
+    assert 'Form' in rv.json['components']['schemas']
+
+    rv = client.post('/', data={'name': 'foo'})
+    assert rv.status_code == 200
+    assert rv.json == {'name': 'foo'}
+
+
+def test_input_with_files_location(app, client):
+    @app.post('/')
+    @app.input(FilesSchema, location='files')
+    def index(files_data):
+        data = {}
+        if 'image' in files_data:
+            data['image'] = True
+        return data
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    # TODO: Failed validating 'oneOf' in schema
+    # https://github.com/p1c2u/openapi-spec-validator/issues/113
+    # validate_spec(rv.json)
+    assert 'multipart/form-data' in rv.json['paths']['/']['post']['requestBody']['content']
+    assert rv.json['paths']['/']['post']['requestBody'][
+        'content']['multipart/form-data']['schema']['$ref'] == '#/components/schemas/Files'
+    assert 'image' in rv.json['components']['schemas']['Files']['properties']
+    assert rv.json['components']['schemas']['Files']['properties']['image']['type'] == 'file'
+
+    rv = client.post(
+        '/',
+        data={'image': (io.BytesIO(b'test'), 'test.jpg')},
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'image': True}
+
+
+def test_input_with_form_and_files_location(app, client):
+    @app.post('/')
+    @app.input(FormAndFilesSchema, location='form_and_files')
+    def index(form_data):
+        data = {}
+        if 'name' in form_data:
+            data['name'] = True
+        if 'image' in form_data:
+            data['image'] = True
+        return data
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    # TODO: Failed validating 'oneOf' in schema
+    # https://github.com/p1c2u/openapi-spec-validator/issues/113
+    # validate_spec(rv.json)
+    assert 'multipart/form-data' in rv.json['paths']['/']['post']['requestBody']['content']
+    assert rv.json['paths']['/']['post']['requestBody'][
+        'content']['multipart/form-data']['schema']['$ref'] == '#/components/schemas/FormAndFiles'
+    assert 'name' in rv.json['components']['schemas']['FormAndFiles']['properties']
+    assert 'image' in rv.json['components']['schemas']['FormAndFiles']['properties']
+    assert rv.json['components']['schemas']['FormAndFiles']['properties']['image']['type'] == 'file'
+
+    rv = client.post(
+        '/',
+        data={'name': 'foo', 'image': (io.BytesIO(b'test'), 'test.jpg')},
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'name': True, 'image': True}
 
 
 def test_bad_input_location(app):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,81 @@
+import io
+
+from werkzeug.datastructures import FileStorage
+
+from .schemas import FilesListSchema
+from .schemas import FilesSchema
+
+
+def test_file_field(app, client):
+    @app.post('/')
+    @app.input(FilesSchema, location='files')
+    def index(files_data):
+        data = {}
+        if 'image' in files_data and isinstance(files_data['image'], FileStorage):
+            data['image'] = True
+        return data
+
+    rv = client.get('/openapi.json')
+    assert rv.status_code == 200
+    assert 'image' in rv.json['components']['schemas']['Files']['properties']
+    assert rv.json['components']['schemas']['Files']['properties']['image']['type'] == 'string'
+    assert rv.json['components']['schemas']['Files']['properties']['image']['format'] == 'binary'
+
+    rv = client.post(
+        '/',
+        data={
+            'image': (io.BytesIO(b'test'), 'test.jpg'),
+        },
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'image': True}
+
+    rv = client.post(
+        '/',
+        data={
+            'image': 'test',
+        },
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 400
+    assert rv.json['detail']['files']['image'] == ['Not a valid file.']
+
+
+def test_multiple_file_field(app, client):
+    @app.post('/')
+    @app.input(FilesListSchema, location='files')
+    def index(files_list_data):
+        data = {'images': True}
+        for f in files_list_data['images']:
+            if not isinstance(f, FileStorage):
+                data['images'] = False
+        return data
+
+    rv = client.post(
+        '/',
+        data={
+            'images': [
+                (io.BytesIO(b'test0'), 'test0.jpg'),
+                (io.BytesIO(b'test1'), 'test1.jpg'),
+                (io.BytesIO(b'test2'), 'test2.jpg'),
+            ]
+        },
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 200
+    assert rv.json == {'images': True}
+
+    rv = client.post(
+        '/',
+        data={
+            'images': [
+                (io.BytesIO(b'test0'), 'test0.jpg'),
+                (io.BytesIO(b'test1'), 'test1.jpg'),
+                'test2',
+            ]
+        },
+        content_type='multipart/form-data'
+    )
+    assert rv.status_code == 400
+    assert rv.json['detail']['files']['images']['2'] == ['Not a valid file.']


### PR DESCRIPTION
- [x] Add `File` field and `form_and_files` location
- [x] Fix the content type of `form` and `files` input locations.
- [x] Raise error if the user uses multiple body input locations ("files", "form", "json").
- [x] Add `Form` field and `form_and_files` location for better form upload support.
- [x] Rewrite the `files` to act like `form_and_files`, so that failed parsed file will be included in the returned data.

File validators will be added later in a separate PR.

The OpenAPI validation failed due to https://github.com/p1c2u/openapi-spec-validator/issues/113.

<!--
For features and bug fixes, before opening a PR, please open an issue describing
the bug or feature the PR will address. You can skip this step if it's a typo fix.

Replace this comment with a description of the change. Describe how it
addresses the linked issue.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #123

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
