### PR TITLE
Support json_or_form location and webargs fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,12 +22,15 @@ Released: --
   - Add `Form` field and `form_and_files` location for better form upload support.
   - Rewrite the `files` to act like `form_and_files`, so that failed parsed file will
     be included in the returned data.
+- Allow to use `json_or_form` location and fields (`DelimitedList` and `DelimitedTuple`)
+  from webargs ([issue #254][issue_254]).
 
 [issue_211]: https://github.com/greyli/apiflask/issues/211
 [issue_231]: https://github.com/greyli/apiflask/issues/231
 [pull_232]: https://github.com/greyli/apiflask/pull/232
 [issue_237]: https://github.com/greyli/apiflask/issues/237
 [issue_123]: https://github.com/greyli/apiflask/issues/123
+[issue_254]: https://github.com/greyli/apiflask/issues/254
 
 
 ## Version 0.12.0

--- a/src/apiflask/fields.py
+++ b/src/apiflask/fields.py
@@ -35,6 +35,8 @@ from marshmallow.fields import TimeDelta as TimeDelta
 from marshmallow.fields import Tuple as Tuple
 from marshmallow.fields import URL as URL
 from marshmallow.fields import UUID as UUID
+from webargs.fields import DelimitedList as DelimitedList
+from webargs.fields import DelimitedTuple as DelimitedTuple
 
 
 class File(Field):

--- a/src/apiflask/scaffold.py
+++ b/src/apiflask/scaffold.py
@@ -23,6 +23,9 @@ from .types import RequestType
 from .types import ResponseReturnValueType
 from .types import SchemaType
 
+BODY_LOCATIONS = ['json', 'files', 'form', 'form_and_files', 'json_or_form']
+SUPPORTED_LOCATIONS = BODY_LOCATIONS + ['query', 'headers', 'cookies', 'querystring']
+
 
 class FlaskParser(BaseFlaskParser):
     """Overwrite the default `webargs.FlaskParser.handle_error`.
@@ -254,7 +257,7 @@ class APIScaffold:
         *Version changed: 1.0*
 
         - Ensure only one input body location was used.
-        - Add `form_and_files` location.
+        - Add `form_and_files` and `json_or_form` (from webargs) location.
         - Rewrite `files` to act as `form_and_files`.
         - Use correct request content type for `form` and `files`.
 
@@ -272,21 +275,14 @@ class APIScaffold:
             schema = schema()
 
         def decorator(f):
-            if location in ['json', 'files', 'form'] and hasattr(f, '_spec') and 'body' in f._spec:
+            is_body_location = location in BODY_LOCATIONS
+            if is_body_location and hasattr(f, '_spec') and 'body' in f._spec:
                 raise RuntimeError(
                     'When using the app.input() decorator, you can only declare one request '
-                    'body location (one of "json", "form", "files", or "form_and_files").'
+                    'body location (one of "json", "form", "files", "form_and_files", '
+                    'and "json_or_form").'
                 )
-            if location not in [
-                'json',
-                'query',
-                'headers',
-                'cookies',
-                'files',
-                'form',
-                'querystring',
-                'form_and_files'
-            ]:
+            if location not in SUPPORTED_LOCATIONS:
                 raise ValueError(
                     'Unknown input location. The supported locations are: "json", "files",'
                     ' "form", "cookies", "headers", "query" (same as "querystring"), and '

--- a/tests/test_decorator_input.py
+++ b/tests/test_decorator_input.py
@@ -185,6 +185,13 @@ def test_input_with_form_and_files_location(app, client):
     ['files', 'form'],
     ['files', 'json'],
     ['form', 'json'],
+    ['form_and_files', 'json'],
+    ['form_and_files', 'form'],
+    ['form_and_files', 'files'],
+    ['json_or_form', 'json'],
+    ['json_or_form', 'files'],
+    ['json_or_form', 'form'],
+    ['json_or_form', 'form_and_files'],
 ])
 def test_multiple_input_body_location(app, locations):
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Expose webargs's `DelimitedList` and `DelimitedTuple` fields.

- fixes #254

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
