### PR TITLE
Always apply custom error processor to HTTP errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Released: --
     be included in the returned data.
 - Allow to use `json_or_form` location and fields (`DelimitedList` and `DelimitedTuple`)
   from webargs ([issue #254][issue_254]).
+- When creating a custom error processor, call it for generic HTTP errors even if the
+  `json_errors` is set to `False` when creating the app instance ([issue #171][issue_171]).
 
 [issue_211]: https://github.com/greyli/apiflask/issues/211
 [issue_231]: https://github.com/greyli/apiflask/issues/231
@@ -31,6 +33,7 @@ Released: --
 [issue_237]: https://github.com/greyli/apiflask/issues/237
 [issue_123]: https://github.com/greyli/apiflask/issues/123
 [issue_254]: https://github.com/greyli/apiflask/issues/254
+[issue_171]: https://github.com/greyli/apiflask/issues/171
 
 
 ## Version 0.12.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,6 +139,20 @@ def test_error_callback(app, client):
     assert rv.json['message'] == 'something was wrong'
 
 
+def test_apply_custom_error_callback_for_generic_errors():
+    app = APIFlask(__name__, json_errors=False)
+    client = app.test_client()
+
+    @app.error_processor
+    def custom_error_handler(e):
+        return {'message': 'custom handler'}, e.status_code
+
+    rv = client.get('/not-exist')
+    assert rv.status_code == 404
+    assert 'message' in rv.json
+    assert rv.json['message'] == 'custom handler'
+
+
 def test_skip_raw_blueprint(app, client):
     raw_bp = Blueprint('raw', __name__)
     api_bp = APIBlueprint('api', __name__, tag='test')


### PR DESCRIPTION
Even when json_error is set to False.

- fixes #171

<!--
If needed, ensure each step in the checklist below is complete. If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the `docs` folder and in code docstring.
- [x] Add an entry in `CHANGES.md` summarizing the change and linking to the issue and your username.
- [x] Add `*Version changed*` or `*Version added*` note in any relevant docs and docstring.
- [x] Run `pytest` and `tox`, no tests failed.
